### PR TITLE
DEVOCS-176: Display historical SentiBoard anomalies (back to 2022)

### DIFF
--- a/apps/elastic/modules/anomalies.py
+++ b/apps/elastic/modules/anomalies.py
@@ -91,7 +91,7 @@ def fetch_anomalies_prev_quarter(normalize=True):
     exposed REST APIs. The start time is set at 00:00:00 of the first day of the temporal interval; the stop time
     is set at 23:59:59 of the day after.
     """
-    logger.debug("Fetching Anomalies in the last Quarter")
+    logger.debug("Fetching Anomalies in the previous Quarter")
 
     # Retrieve data takes in the previous, completed quarter and store results of query in cache
     start_date, end_date = date_utils.prev_quarter_interval_from_date(datetime.today())

--- a/apps/ingestion/anomalies_ingestor.py
+++ b/apps/ingestion/anomalies_ingestor.py
@@ -153,9 +153,9 @@ class AnomaliesIngestor:
             elif origin == "MP":                  
                 anomaly["category"] = "Acquisition"
                 logger.info("[ORIGIN_MAP] MP anomaly found: key=%s title=%s", src.get("key"), src.get("title"))
-            elif origin in ("IPF", "ADGS"):      
+            elif origin in ("IPF", "ADGS"):
                 anomaly["category"] = "Production"
-                logger.info("[ORIGIN_MAP] MP anomaly found: key=%s title=%s", src.get("key"), src.get("title"))
+                logger.info("[ORIGIN_MAP] IPF/ADGS anomaly found: key=%s title=%s", src.get("key"), src.get("title"))
             # nothing mapping directly to Calibration
             # in case of Other, keep as '', let the rest of the code handle it
 

--- a/apps/models/anomalies.py
+++ b/apps/models/anomalies.py
@@ -12,6 +12,7 @@ behalf of TPZ to fulfill the purpose for which the document was
 delivered to him.
 """
 
+import ast
 import logging
 from datetime import datetime
 
@@ -19,6 +20,20 @@ from apps import db
 from apps.utils.db_utils import generate_uuid
 
 logger = logging.getLogger(__name__)
+
+# The upstream anomaly feed renamed the key prefix "PDGSANOM-" to "GSANOM-" for
+# the same anomalies. Both forms refer to one logical anomaly, so we canonicalize
+# every key to the "GSANOM-" form before lookups/inserts. This keeps a single row
+# per anomaly and prevents the old/new prefixes from creating duplicate rows.
+_LEGACY_KEY_PREFIX = "PDGSANOM"
+_CANONICAL_KEY_PREFIX = "GSANOM"
+
+
+def normalize_anomaly_key(key):
+    """Return the canonical form of an anomaly key (PDGSANOM-* -> GSANOM-*)."""
+    if key and key.startswith(_LEGACY_KEY_PREFIX):
+        return _CANONICAL_KEY_PREFIX + key[len(_LEGACY_KEY_PREFIX):]
+    return key
 
 
 class Anomalies(db.Model):
@@ -62,8 +77,11 @@ def save_anomaly(
     datatakes_completeness,
     newsLink=None,
     newsTitle=None,
-    modify_date=datetime.now(),
+    modify_date=None,
 ):
+    key = normalize_anomaly_key(key)
+    if modify_date is None:
+        modify_date = datetime.now()
     try:
         anomalies = Anomalies(
             id=str(generate_uuid()),
@@ -90,6 +108,40 @@ def save_anomaly(
     return None
 
 
+def _build_datatakes_completeness(environment, existing=None):
+    """Build the datatakes_completeness entries from the ``environment`` string.
+
+    When ``existing`` (the current stored value, either a list or its string
+    repr) is provided, already-computed completeness counters are preserved for
+    every datatake ID that is still present, so re-ingesting an anomaly does not
+    reset the L0_/L1_/L2_ values populated by the completeness refresh job.
+    """
+    existing_by_id = {}
+    if existing:
+        if isinstance(existing, str):
+            try:
+                existing = ast.literal_eval(existing)
+            except (ValueError, SyntaxError):
+                existing = []
+        if isinstance(existing, list):
+            for entry in existing:
+                if isinstance(entry, dict) and entry.get("datatakeID"):
+                    existing_by_id[entry["datatakeID"]] = entry
+
+    datatakes_completeness = []
+    if environment is not None and len(environment) > 0:
+        for datatake_id in environment.split(";"):
+            if datatake_id is None or len(datatake_id) == 0:
+                continue
+            if datatake_id in existing_by_id:
+                datatakes_completeness.append(existing_by_id[datatake_id])
+            else:
+                datatakes_completeness.append(
+                    {"datatakeID": datatake_id, "L0_": 0, "L1_": 0, "L2_": 0}
+                )
+    return datatakes_completeness
+
+
 def update_anomaly(
     title,
     key,
@@ -103,8 +155,11 @@ def update_anomaly(
     environment,
     newsLink=None,
     newsTitle=None,
-    modify_date=datetime.now(),
+    modify_date=None,
 ):
+    key = normalize_anomaly_key(key)
+    if modify_date is None:
+        modify_date = datetime.now()
     try:
         anomaly = db.session.query(Anomalies).filter(Anomalies.key == key).first()
         if anomaly is not None:
@@ -118,15 +173,13 @@ def update_anomaly(
             anomaly.category = category
             anomaly.impactedSatellite = impacted_satellite
             anomaly.impactedItem = impacted_item
+            anomaly.datatakes_completeness = str(
+                _build_datatakes_completeness(
+                    environment, existing=anomaly.datatakes_completeness
+                )
+            )
         else:
-            datatakes_completeness = []
-            if environment is not None and len(environment) > 0:
-                datatake_ids = environment.split(";")
-                for datatake_id in datatake_ids:
-                    if datatake_id is None or len(datatake_id) == 0:
-                        continue
-                    entry = {"datatakeID": datatake_id, "L0_": 0, "L1_": 0, "L2_": 0}
-                    datatakes_completeness.append(entry)
+            datatakes_completeness = _build_datatakes_completeness(environment)
             anomaly = Anomalies(
                 id=str(generate_uuid()),
                 key=key,
@@ -199,10 +252,9 @@ def get_anomalies(start_date=None, end_date=None):
             return Anomalies.query.order_by(Anomalies.publicationDate.desc()).all()
         else:
             return (
-                Anomalies.query.filter(Anomalies.start != None)
-                .filter(Anomalies.end != None)
-                .filter(Anomalies.start >= start_date)
-                .filter(Anomalies.start <= end_date)
+                Anomalies.query.filter(Anomalies.publicationDate != None)
+                .filter(Anomalies.publicationDate >= start_date)
+                .filter(Anomalies.publicationDate <= end_date)
                 .order_by(Anomalies.publicationDate.asc())
                 .all()
             )

--- a/apps/routes/home/routes.py
+++ b/apps/routes/home/routes.py
@@ -773,8 +773,10 @@ def events_data():
 
         def serialize_anomalie(a):
             src = a.get("_source", a)
-            if src.get("origin") == "Dashboard":
-                return None
+            # NOTE: Dashboard-origin anomalies are dropped upstream at ingestion
+            # (apps/ingestion/anomalies_ingestor.py), so they never reach the DB
+            # this cache is built from. The stored Anomalies rows carry no "origin"
+            # field, hence there is no origin filter to apply here.
             date_str = (
                 src.get("occurence_date")
                 or src.get("occurrence_date")

--- a/apps/routes/rest/routes.py
+++ b/apps/routes/rest/routes.py
@@ -327,10 +327,10 @@ def delete_anomalies():
         from apps.models.anomalies import Anomalies
         from apps import db
 
-        deleted = (
+        deleted = ( 
             db.session.query(Anomalies)
-            .filter(Anomalies.start >= start_date)
-            .filter(Anomalies.start <= end_date)
+            .filter(Anomalies.publicationDate >= start_date)
+            .filter(Anomalies.publicationDate <= end_date)
             .delete(synchronize_session=False)
         )
         db.session.commit()

--- a/apps/utils/events_utils.py
+++ b/apps/utils/events_utils.py
@@ -240,7 +240,7 @@ def calc_completeness(values):
 def build_event_instance(a, logger=None):
 
     # Parse start/end time from publicationDate
-    date_str = a.get("start") or a.get("publicationDate")
+    date_str = a.get("publicationDate") or a.get("start")
     start_date = None
     if date_str:
         start_date = to_utc(date_str)

--- a/scripts/backfill_anomalies_range.py
+++ b/scripts/backfill_anomalies_range.py
@@ -1,0 +1,159 @@
+# -*- encoding: utf-8 -*-
+"""
+Chunked historical backfill of anomalies from the Elastic/CAMS source.
+
+Why this exists
+---------------
+The /admin/backfill_anomalies HTTP endpoint runs the whole date range inside a
+single request, so a multi-year backfill (e.g. 2022 -> today) reliably exceeds
+the nginx/gunicorn timeout and dies part-way. This script does the same work but
+as a long-running process (no HTTP timeout), splitting the range into month- or
+quarter-sized chunks and ingesting them one at a time with progress logging.
+
+It deliberately stops ~3 months before today by default: the recent window is
+already kept current by the daily scheduled ingestion (which covers the last
+quarter), so there is no need to re-ingest it here.
+
+Safety
+------
+* Idempotent: ingestion upserts by the canonical anomaly key
+  (see apps.models.anomalies.update_anomaly / normalize_anomaly_key), so
+  re-running a chunk updates rows instead of duplicating them.
+* --dry-run only *fetches* from Elastic and reports counts per chunk; it never
+  writes to the database.
+
+Usage (typically inside the container, where Elastic is reachable)
+------------------------------------------------------------------
+    # Preview what would be ingested, month by month:
+    python -m scripts.backfill_anomalies_range --dry-run
+
+    # Backfill 2022-01-01 up to ~3 months ago, in monthly chunks:
+    python -m scripts.backfill_anomalies_range
+
+    # Custom range / quarterly chunks:
+    python -m scripts.backfill_anomalies_range --start 2022-01-01 --end 2026-03-01 --chunk quarter
+
+Target DB: defaults to the local sqlite file (apps/db/db.sqlite3); override with
+SENTIBOARD_DB_URI if needed.
+"""
+
+import argparse
+import os
+import socket
+
+# Importing the apps package runs a module-level Redis probe
+# (socket.connect_ex on 127.0.0.1:7478) that blocks where the port is filtered.
+# Cap the timeout during import, then restore it so DB/Elastic sockets are
+# unaffected. (Inside the container Redis is reachable, so this is a no-op there.)
+_prev_timeout = socket.getdefaulttimeout()
+socket.setdefaulttimeout(5)
+try:
+    import apps
+    from apps import db
+    import apps.config  # noqa: F401 — side effect: populates ConfigCache (Elastic config)
+    from dateutil.relativedelta import relativedelta
+    from apps.ingestion.anomalies_ingestor import AnomaliesIngestor
+finally:
+    socket.setdefaulttimeout(_prev_timeout)
+
+from datetime import datetime
+
+from flask import Flask
+
+
+def _resolve_db_uri():
+    override = os.getenv("SENTIBOARD_DB_URI") or os.getenv("SQLALCHEMY_DATABASE_URI")
+    if override:
+        return override
+    apps_dir = os.path.dirname(os.path.abspath(apps.__file__))
+    return "sqlite:///" + os.path.join(apps_dir, "db", "db.sqlite3")
+
+
+def _build_minimal_app(db_uri):
+    """A bare Flask app bound to the target DB (no blueprints/scheduler)."""
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    return app
+
+
+def _chunks(start, end, step_months):
+    """Yield [chunk_start, chunk_end) windows covering [start, end)."""
+    cur = start
+    while cur < end:
+        nxt = min(cur + relativedelta(months=step_months), end)
+        yield cur, nxt
+        cur = nxt
+
+
+def _parse_date(s):
+    return datetime.strptime(s, "%Y-%m-%d")
+
+
+def run(start, end, step_months, dry_run):
+    ingestor = AnomaliesIngestor()
+    total_seen = total_ingested = total_skipped = 0
+
+    windows = list(_chunks(start, end, step_months))
+    print("Backfill {} -> {} in {} chunk(s) of {} month(s){}".format(
+        start.date(), end.date(), len(windows), step_months,
+        "  [DRY-RUN]" if dry_run else ""))
+
+    for i, (cs, ce) in enumerate(windows, 1):
+        label = "[{}/{}] {} -> {}".format(i, len(windows), cs.date(), ce.date())
+        try:
+            if dry_run:
+                records = ingestor.get_anomalies_elastic(start=cs, end=ce)
+                n = len(records)
+                total_seen += n
+                print("  {}  would ingest {} anomalies".format(label, n))
+            else:
+                ingested, skipped = ingestor.ingest_anomalies_range(start=cs, end=ce)
+                total_ingested += ingested
+                total_skipped += skipped
+                print("  {}  ingested {}, skipped {}".format(label, ingested, skipped))
+        except Exception as ex:  # one bad chunk shouldn't abort the whole run
+            print("  {}  ERROR: {}".format(label, ex))
+
+    print("\nDone.")
+    if dry_run:
+        print("  total anomalies that would be ingested: {}".format(total_seen))
+    else:
+        print("  total ingested: {}  total skipped: {}".format(total_ingested, total_skipped))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Chunked historical anomaly backfill.")
+    parser.add_argument("--start", default="2022-01-01", metavar="YYYY-MM-DD",
+                        help="range start (default 2022-01-01)")
+    parser.add_argument("--end", default=None, metavar="YYYY-MM-DD",
+                        help="range end (default: ~3 months ago, since the daily "
+                             "ingestion already covers the recent quarter)")
+    parser.add_argument("--chunk", choices=("month", "quarter"), default="month",
+                        help="chunk size (default month)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="only fetch and report counts; do not write to the DB")
+    args = parser.parse_args()
+
+    start = _parse_date(args.start)
+    if args.end:
+        end = _parse_date(args.end)
+    else:
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        end = today - relativedelta(months=3)
+
+    if start >= end:
+        raise SystemExit("start ({}) must be before end ({})".format(start.date(), end.date()))
+
+    step_months = 1 if args.chunk == "month" else 3
+
+    db_uri = _resolve_db_uri()
+    print("Target DB: {}".format(db_uri))
+    app = _build_minimal_app(db_uri)
+    with app.app_context():
+        run(start, end, step_months, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dedupe_anomaly_keys.py
+++ b/scripts/dedupe_anomaly_keys.py
@@ -1,0 +1,198 @@
+# -*- encoding: utf-8 -*-
+"""
+One-time data migration: collapse duplicate anomalies caused by the upstream
+key-prefix rename ("PDGSANOM-" -> "GSANOM-").
+
+Background
+----------
+The same logical anomaly was ingested under two different keys over time
+(old: ``PDGSANOM-<n>``, new: ``GSANOM-<n>``). Because ``update_anomaly`` dedups
+on an exact key match, an old-range backfill inserted the new-keyed row instead
+of updating the existing one, producing duplicate calendar traces. The old row
+also holds the computed ``datatakes_completeness`` snapshot, which cannot be
+recomputed (data-availability detail is restricted to ~3 months).
+
+What this script does
+---------------------
+Groups every anomaly by its canonical key (``normalize_anomaly_key``). For each
+group:
+  * 1 row  -> if its key is the legacy form, rename it to the canonical form.
+  * 2 rows -> keep the canonical (GSANOM) row as the survivor; if the survivor
+              has no real completeness but its legacy twin does, copy the twin's
+              ``datatakes_completeness`` onto the survivor; then delete the twin.
+
+The operation is idempotent: a second run finds nothing to change.
+
+Usage
+-----
+    # Safe preview (no writes) — DEFAULT:
+    python -m scripts.dedupe_anomaly_keys
+
+    # Apply the changes:
+    python -m scripts.dedupe_anomaly_keys --apply
+
+    # Apply, snapshotting the table into anomalies_backup_<suffix> first:
+    python -m scripts.dedupe_anomaly_keys --apply --backup pre_dedupe
+
+By default it targets the local sqlite DB (apps/db/db.sqlite3). On staging/prod,
+point it at the live DB by exporting SENTIBOARD_DB_URI (a SQLAlchemy URI), e.g.
+    export SENTIBOARD_DB_URI="postgresql://user:pass@host:5432/dbname"
+"""
+
+import argparse
+import ast
+import os
+import socket
+from collections import defaultdict
+
+# Importing the apps package runs a module-level Redis probe
+# (socket.connect_ex on 127.0.0.1:7478). Where that port is filtered rather than
+# refused, the probe blocks for the full TCP connect timeout. Cap it during the
+# import, then restore the previous default so DB sockets are unaffected.
+_prev_timeout = socket.getdefaulttimeout()
+socket.setdefaulttimeout(3)
+try:
+    import apps
+    from apps import db
+    from apps.models.anomalies import Anomalies, normalize_anomaly_key
+finally:
+    socket.setdefaulttimeout(_prev_timeout)
+
+from flask import Flask
+
+
+def _resolve_db_uri():
+    """SQLAlchemy URI for the target DB.
+
+    We deliberately do NOT import apps.config: instantiating its config classes
+    runs manage_cache_config(), which connects to Redis and hangs where Redis is
+    not reachable. Honor an explicit override env var, otherwise fall back to the
+    same local sqlite file the app uses (apps/db/db.sqlite3).
+    """
+    override = os.getenv("SENTIBOARD_DB_URI") or os.getenv("SQLALCHEMY_DATABASE_URI")
+    if override:
+        return override
+    apps_dir = os.path.dirname(os.path.abspath(apps.__file__))
+    return "sqlite:///" + os.path.join(apps_dir, "db", "db.sqlite3")
+
+
+def _build_minimal_app(db_uri):
+    """A bare Flask app bound to the target DB.
+
+    We deliberately avoid apps.create_app() — it boots blueprints, the
+    scheduler and Elasticsearch connections, which this data migration does not
+    need (and which block/hang in a headless run).
+    """
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = db_uri
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    return app
+
+
+def _has_real_completeness(raw):
+    """True if the stored datatakes_completeness has any non-zero L0/L1/L2 value."""
+    try:
+        entries = ast.literal_eval(raw or "[]")
+    except (ValueError, SyntaxError):
+        return False
+    if not isinstance(entries, list):
+        return False
+    for entry in entries:
+        if isinstance(entry, dict) and any(
+            isinstance(entry.get(k), (int, float)) and entry.get(k)
+            for k in ("L0_", "L1_", "L2_")
+        ):
+            return True
+    return False
+
+
+def _backup_table(suffix):
+    """Snapshot the anomalies table into anomalies_backup_<suffix> (same engine)."""
+    backup = "anomalies_backup_" + suffix
+    # CREATE TABLE AS SELECT is supported by sqlite, postgres and mysql.
+    db.session.execute(
+        db.text("CREATE TABLE {} AS SELECT * FROM anomalies".format(backup))
+    )
+    db.session.commit()
+    print("  backup table created: {}".format(backup))
+
+
+def run(apply_changes):
+    rows = Anomalies.query.all()
+    print("Loaded {} anomalies".format(len(rows)))
+
+    groups = defaultdict(list)
+    for r in rows:
+        groups[normalize_anomaly_key(r.key)].append(r)
+
+    renamed = merged = deleted = donated = untouched = 0
+
+    for norm_key, members in groups.items():
+        if len(members) == 1:
+            r = members[0]
+            if r.key != norm_key:
+                print("  RENAME  {!r} -> {!r}".format(r.key, norm_key))
+                r.key = norm_key
+                renamed += 1
+            else:
+                untouched += 1
+            continue
+
+        # >1 member: same anomaly under both prefixes. Keep the canonical row.
+        survivor = next((m for m in members if m.key == norm_key), members[0])
+        others = [m for m in members if m is not survivor]
+
+        if not _has_real_completeness(survivor.datatakes_completeness):
+            donor = next(
+                (m for m in others if _has_real_completeness(m.datatakes_completeness)),
+                None,
+            )
+            if donor is not None:
+                survivor.datatakes_completeness = donor.datatakes_completeness
+                donated += 1
+
+        survivor.key = norm_key
+        for m in others:
+            print("  MERGE   delete {!r} (id={}) into survivor {!r}".format(
+                m.key, m.id, norm_key))
+            db.session.delete(m)
+            deleted += 1
+        merged += 1
+
+    print("\nSummary:")
+    print("  duplicate groups merged : {}".format(merged))
+    print("  legacy rows deleted     : {}".format(deleted))
+    print("  completeness donated    : {}".format(donated))
+    print("  twinless rows renamed   : {}".format(renamed))
+    print("  rows already canonical  : {}".format(untouched))
+
+    if not apply_changes:
+        db.session.rollback()
+        print("\nDRY-RUN — no changes written. Re-run with --apply to commit.")
+        return
+
+    db.session.commit()
+    print("\nAPPLIED — changes committed.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Collapse PDGSANOM/GSANOM anomaly duplicates.")
+    parser.add_argument("--apply", action="store_true",
+                        help="commit changes (default is a dry-run preview)")
+    parser.add_argument("--backup", metavar="SUFFIX", default=None,
+                        help="snapshot anomalies into anomalies_backup_<SUFFIX> before applying")
+    args = parser.parse_args()
+
+    db_uri = _resolve_db_uri()
+    print("Target DB: {}".format(db_uri))
+    app = _build_minimal_app(db_uri)
+
+    with app.app_context():
+        if args.apply and args.backup:
+            _backup_table(args.backup)
+        run(apply_changes=args.apply)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/unit_tests/anomalies_datatakes_completeness_test.py
+++ b/test/unit_tests/anomalies_datatakes_completeness_test.py
@@ -1,0 +1,83 @@
+import unittest
+
+from apps.models.anomalies import _build_datatakes_completeness, normalize_anomaly_key
+
+
+class NormalizeAnomalyKeyTest(unittest.TestCase):
+    def test_legacy_prefix_is_rewritten(self):
+        self.assertEqual(normalize_anomaly_key("PDGSANOM-11869"), "GSANOM-11869")
+
+    def test_canonical_prefix_unchanged(self):
+        self.assertEqual(normalize_anomaly_key("GSANOM-11869"), "GSANOM-11869")
+
+    def test_unrelated_key_unchanged(self):
+        self.assertEqual(normalize_anomaly_key("FOO-123"), "FOO-123")
+
+    def test_none_and_empty_are_safe(self):
+        self.assertIsNone(normalize_anomaly_key(None))
+        self.assertEqual(normalize_anomaly_key(""), "")
+
+    def test_only_leading_prefix_is_touched(self):
+        # "PD" elsewhere in the string must not be altered.
+        self.assertEqual(normalize_anomaly_key("GSANOM-PD-5"), "GSANOM-PD-5")
+
+
+class BuildDatatakesCompletenessTest(unittest.TestCase):
+    def test_build_from_environment_when_no_existing(self):
+        result = _build_datatakes_completeness("DT1;DT2")
+        self.assertEqual(
+            result,
+            [
+                {"datatakeID": "DT1", "L0_": 0, "L1_": 0, "L2_": 0},
+                {"datatakeID": "DT2", "L0_": 0, "L1_": 0, "L2_": 0},
+            ],
+        )
+
+    def test_empty_environment_returns_empty_list(self):
+        self.assertEqual(_build_datatakes_completeness(""), [])
+        self.assertEqual(_build_datatakes_completeness(None), [])
+
+    def test_skips_empty_segments(self):
+        result = _build_datatakes_completeness("DT1;;DT2;")
+        self.assertEqual([e["datatakeID"] for e in result], ["DT1", "DT2"])
+
+    def test_merge_preserves_existing_counters(self):
+        existing = [
+            {"datatakeID": "DT1", "L0_": 5, "L1_": 3, "L2_": 1},
+        ]
+        result = _build_datatakes_completeness("DT1", existing=existing)
+        # The already-computed counters for DT1 must be kept, not reset to zero.
+        self.assertEqual(result, [{"datatakeID": "DT1", "L0_": 5, "L1_": 3, "L2_": 1}])
+
+    def test_merge_keeps_existing_and_zeroes_new_ids(self):
+        existing = [{"datatakeID": "DT1", "L0_": 5, "L1_": 3, "L2_": 1}]
+        result = _build_datatakes_completeness("DT1;DT2", existing=existing)
+        self.assertEqual(
+            result,
+            [
+                {"datatakeID": "DT1", "L0_": 5, "L1_": 3, "L2_": 1},
+                {"datatakeID": "DT2", "L0_": 0, "L1_": 0, "L2_": 0},
+            ],
+        )
+
+    def test_merge_drops_ids_no_longer_in_environment(self):
+        existing = [
+            {"datatakeID": "DT1", "L0_": 5, "L1_": 3, "L2_": 1},
+            {"datatakeID": "DT2", "L0_": 9, "L1_": 9, "L2_": 9},
+        ]
+        result = _build_datatakes_completeness("DT1", existing=existing)
+        self.assertEqual(result, [{"datatakeID": "DT1", "L0_": 5, "L1_": 3, "L2_": 1}])
+
+    def test_merge_accepts_string_repr_of_existing(self):
+        # The DB stores the field as the str() of a list (single-quoted repr).
+        existing = "[{'datatakeID': 'DT1', 'L0_': 5, 'L1_': 3, 'L2_': 1}]"
+        result = _build_datatakes_completeness("DT1", existing=existing)
+        self.assertEqual(result, [{"datatakeID": "DT1", "L0_": 5, "L1_": 3, "L2_": 1}])
+
+    def test_merge_tolerates_malformed_existing_string(self):
+        result = _build_datatakes_completeness("DT1", existing="not-a-list")
+        self.assertEqual(result, [{"datatakeID": "DT1", "L0_": 0, "L1_": 0, "L2_": 0}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Previously, the UI and hourly ingestor only fetched and displayed the last 3 months of anomalies. This PR adds the necessary scripts to safely backfill historical OpenSearch data into the DB.


- **Key Normalization**: Canonicalized OpenSearch keys (`PDGSANOM-* → GSANOM-*`) during ingestion to prevent duplicate calendar events.

- **Bugfix**: `update_anomaly` no longer zeroes out `datatakes_completeness` during re-ingestion.
- **Backfill Script**: Added `scripts/backfill_anomalies_range.py` to fetch historical data in chunks, avoiding HTTP/gunicorn timeouts.
- **Migration Script**: Added `scripts/dedupe_anomaly_keys.py` to clean up existing duplicate rows in the DB.
- **Tests**: Added unit tests for key normalization and the completeness merge.