### PR TITLE
DEVOCS-204: Centralize satellite metadata in a single registry + prepare S3C onboarding

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -504,6 +504,15 @@ def create_app(config):
             page_url=page_url,
         )
 
+    # Expose the centralized satellite registry to every template so the
+    # frontend reads satellite metadata from a single source of truth
+    # (apps/utils/satellite_registry.py) instead of hardcoded JS lists.
+    @app.context_processor
+    def inject_satellite_registry():
+        from apps.utils.satellite_registry import to_js_registry
+
+        return dict(satellite_registry_js=to_js_registry())
+
     print("Starting Cache ...")
     flask_cache.init_app(app)
     print("Starting Database ...")

--- a/apps/cache/modules/acquisitionassets.py
+++ b/apps/cache/modules/acquisitionassets.py
@@ -22,7 +22,7 @@ from satellite_czml import satellite
 from satellite_czml import satellite_czml
 from satellite_tle import fetch_tle_from_celestrak
 from apps.utils.tle_fetcher import get_latest_tle
-
+from apps.utils.satellite_registry import sat_ids, norad_id_map, color_map, marker_map
 from apps import flask_cache
 
 logger = logging.getLogger(__name__)
@@ -32,20 +32,6 @@ orbits_cache_key = "/api/acquisition/satellite/orbits"
 stations_cache_key = "/api/acquisition/stations"
 
 assets_cache_duration = 604800
-
-sat_ids = ["S1A", "S1C", "S1D", "S2A", "S2B", "S2C", "S3A", "S3B", "S5P"]
-norad_id_map = {
-    "S1A": 39634,
-    "S1B": 41456,
-    "S1C": 62261,
-    "S1D": 66315,
-    "S2A": 40697,
-    "S2B": 42063,
-    "S2C": 60989,
-    "S3A": 41335,
-    "S3B": 43437,
-    "S5P": 42969,
-}
 
 
 """ def get_latest_tle(sat_id):
@@ -185,31 +171,7 @@ def load_satellite_orbits():
 
     # Init satellite and color maps
     multiple_sats = []
-    color_map = {
-        "S1A": [72, 171, 247, 255],
-        "S1B": [72, 171, 247, 255],
-        "S1C": [72, 171, 247, 255],
-        "S1D": [72, 171, 247, 255],
-        "S2A": [49, 206, 54, 255],
-        "S2B": [49, 206, 54, 255],
-        "S2C": [49, 206, 54, 255],
-        "S3A": [255, 173, 70, 255],
-        "S3B": [255, 173, 70, 255],
-        "S5P": [104, 97, 206, 255],
-    }
-    marker_map = {
-        "S1A": "static/assets/img/sentinel-1.png",
-        "S1B": "static/assets/img/sentinel-1.png",
-        "S1C": "static/assets/img/sentinel-1.png",
-        "S1D": "static/assets/img/sentinel-1.png",
-        "S2A": "static/assets/img/sentinel-2.png",
-        "S2B": "static/assets/img/sentinel-2.png",
-        "S2C": "static/assets/img/sentinel-2.png",
-        "S3A": "static/assets/img/sentinel-3.png",
-        "S3B": "static/assets/img/sentinel-3.png",
-        "S5P": "static/assets/img/sentinel-5p.png",
-    }
-
+   
     # To avoid breaking the scheduler, protect the connection loop in a try-except block
     try:
 

--- a/apps/elastic/modules/archive_statistics.py
+++ b/apps/elastic/modules/archive_statistics.py
@@ -16,6 +16,7 @@ import logging
 from time import perf_counter
 
 from apps.cache.cache import PublicationProductTreeCache, ConfigCache
+from apps.utils.satellite_registry import get_mission_satellites
 from apps.elastic import client as elastic_client
 from apps.utils import date_utils as utils
 
@@ -30,9 +31,9 @@ def get_cds_archive_size_by_mission(start_date, end_date, mission):
         f"[BEG] CDS LONG TERM ARCHIVE VOLUME for mission {mission}, start: {start_date}, end: {end_date}"
     )
     results = []
-    cfg = ConfigCache.load_object("archive_config")
-    mission_satellites = cfg.get("mission_satellites")
-    # archive_levels = cfg.get('statistics_levels')
+    # Long-term archive includes decommissioned units (e.g. S1B), so use the
+    # full registry list rather than only active satellites.
+    mission_satellites = get_mission_satellites(active_only=False)
     archive_levels = ["L0_"]
 
     for satellite in mission_satellites.get(mission):

--- a/apps/elastic/modules/datatakes.py
+++ b/apps/elastic/modules/datatakes.py
@@ -122,7 +122,6 @@ def _get_cds_s1s2_datatakes(start_date, end_date):
             "s1", CDS_MISSIONS["s1"]
         ) + _build_cds_completeness_indices("s2", CDS_MISSIONS["s2"])
 
-        logger.info("[CDS][S1S2] Querying indices: %s", indices)
         elastic = elastic_client.ElasticClient()
 
         logger.info("[CDS][S1S2] Querying indexes:%s", indices)

--- a/apps/elastic/modules/datatakes.py
+++ b/apps/elastic/modules/datatakes.py
@@ -21,36 +21,13 @@ import apps.ingestion.anomalies_ingestor as anomalies_ingestor
 from apps.elastic import client as elastic_client
 from apps.models import anomalies as anomalies_model
 from apps.utils import date_utils
+from apps.utils.satellite_registry import satellites_mission_map, CDS_MISSIONS, mission_time_thresholds, ids_for_mission
 
 logger = logging.getLogger(__name__)
 
 level_ids = {
     "S3": {"L0_": "L0_", "L1_": "L1_", "L2_": "L2_"},
     "S5": {"L0_": "L0_", "L1_": "L1B", "L2_": "L2_"},
-}
-
-satellites_mission_map = {
-    "S1A": "S1",
-    "S1B": "S1",
-    "S1C": "S1",
-    "S1D": "S1",
-    "S2A": "S2",
-    "S2B": "S2",
-    "S2C": "S2",
-    "S2D": "S2",
-    "S3A": "S3",
-    "S3B": "S3",
-    "S3D": "S3",
-    "S5P": "S5",
-}
-
-mission_time_thresholds = {"S1": 8, "S2": 10, "S3": 696, "S5": 48}
-
-CDS_MISSIONS = {
-    "s1": ["s1a", "s1c", "s1d"],
-    "s2": ["s2a", "s2b", "s2c"],
-    "s3": ["s3a", "s3b"],
-    "s5": ["s5p"],
 }
 
 ELASTIC_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -145,6 +122,7 @@ def _get_cds_s1s2_datatakes(start_date, end_date):
             "s1", CDS_MISSIONS["s1"]
         ) + _build_cds_completeness_indices("s2", CDS_MISSIONS["s2"])
 
+        logger.info("[CDS][S1S2] Querying indices: %s", indices)
         elastic = elastic_client.ElasticClient()
 
         logger.info("[CDS][S1S2] Querying indexes:%s", indices)
@@ -186,14 +164,18 @@ def _get_cds_s1s2_datatakes(start_date, end_date):
     except Exception as ex:
         logger.error(ex)
 
-    # Calculate completeness for every datatake
+    # Calculate completeness for every datatake. Use all known mission units
+    # (including decommissioned ones such as S1B) so historical datatakes are
+    # still classified correctly.
+    s1_sats = ids_for_mission("S1", active_only=False)
+    s2_sats = ids_for_mission("S2", active_only=False)
     clean_results = []
     for dt in results:
         dt_id = dt["_id"]
         completeness = {}
-        if any(s1_sat in dt_id for s1_sat in ["S1A", "S1B", "S1C", "S1D"]):
+        if any(s1_sat in dt_id for s1_sat in s1_sats):
             completeness = _calc_s1_datatake_completeness(dt)
-        elif any(s2_sat in dt_id for s2_sat in ["S2A", "S2B", "S2C"]):
+        elif any(s2_sat in dt_id for s2_sat in s2_sats):
             completeness = _calc_s2_datatake_completeness(dt)
         for key in list(dt["_source"]):
             if key.endswith("local_percentage"):

--- a/apps/ingestion/acq_plan_ingestor.py
+++ b/apps/ingestion/acq_plan_ingestor.py
@@ -23,6 +23,7 @@ from apps.ingestion.acquisition_plans.acq_plan_kml_loader import (
 )
 from apps.ingestion.orbit_acquisitions import AcquisitionPlanOrbitDatatakeBuilder
 from apps.cache.cache import ConfigCache
+from apps.utils.satellite_registry import get_mission_satellites
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,9 @@ logger = logging.getLogger(__name__)
 #    Latest Ingestor
 #    PreviousYears Ingestor
 
-acq_plans_mission_satellites = ConfigCache.load_object("acq_plans_mission_satellites")
+# Active satellites with a published acquisition plan, per mission — sourced
+# from the central satellite registry (was config: acq_plans_mission_satellites).
+acq_plans_mission_satellites = get_mission_satellites(active_only=True)
 
 # Missions whose KML Acq Plan is retrieved from ESA
 kml_acq_plans_missions = ["S1", "S2"]

--- a/apps/ingestion/acquisition_plans/acq_link_page.py
+++ b/apps/ingestion/acquisition_plans/acq_link_page.py
@@ -23,6 +23,7 @@ from typing import List
 from urllib.parse import urljoin, urlparse
 
 from apps.cache.cache import ConfigCache
+from apps.utils.satellite_registry import get_acqplan_div_map
 from apps.ingestion import news_scraper as scraper
 from apps.utils import html_utils as html_utils
 
@@ -268,7 +269,9 @@ class AcqPlanKmlRetriever:
         page_contents = html_utils.get_html_page(url)
         html_page = scraper.ScarperHtml(page_contents)
         # For each platform in platform list
-        acqplan_div = mission_cfg["acqplan_div"]
+        # acqplan_div now comes from the central satellite registry; the
+        # scraper URLs still come from config (acqplans_config).
+        acqplan_div = get_acqplan_div_map().get(self._mission, {})
         logger.debug("Scraping from page div: %s", acqplan_div)
         acqplan_config = {"acqplan_div": acqplan_div}
         plan_retriever = AcqPlanLinksPageParser(

--- a/apps/ingestion/acquisition_plans/orbit_datatake_acquisitions.py
+++ b/apps/ingestion/acquisition_plans/orbit_datatake_acquisitions.py
@@ -26,6 +26,7 @@ import pytz
 from skyfield.units import Angle
 
 from apps.elastic.modules.datatakes import ELASTIC_TIME_FORMAT
+from apps.utils.satellite_registry import swaths
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +34,7 @@ DATATAKE_ID_KEY = "datatake_id"
 OBSERVATION_START_KEY = "observation_time_start"
 OBSERVATION_END_KEY = "observation_time_stop"
 
-# SWATHS for Satellites
-# IN Km
-
-swaths = {"S3A": 1270, "S3B": 1270, "S5P": 2600}
+# SWATHS for Satellites (km) — sourced from apps.utils.satellite_registry.
 
 
 @dataclass

--- a/apps/ingestion/anomalies_ingestor.py
+++ b/apps/ingestion/anomalies_ingestor.py
@@ -153,9 +153,9 @@ class AnomaliesIngestor:
             elif origin == "MP":                  
                 anomaly["category"] = "Acquisition"
                 logger.info("[ORIGIN_MAP] MP anomaly found: key=%s title=%s", src.get("key"), src.get("title"))
-            elif origin in ("IPF", "ADGS"):      
+            elif origin in ("IPF", "ADGS"):
                 anomaly["category"] = "Production"
-                logger.info("[ORIGIN_MAP] MP anomaly found: key=%s title=%s", src.get("key"), src.get("title"))
+                logger.info("[ORIGIN_MAP] %s anomaly found: key=%s title=%s", origin, src.get("key"), src.get("title"))
             # nothing mapping directly to Calibration
             # in case of Other, keep as '', let the rest of the code handle it
 

--- a/apps/ingestion/anomalies_ingestor.py
+++ b/apps/ingestion/anomalies_ingestor.py
@@ -250,7 +250,10 @@ class AnomaliesIngestor:
         ingested = 0
         skipped = 0
     
-        S1D_CUTOFF = datetime(2026, 4, 17)  # naive, local comparison
+        # S1D operational cutoff (naive, local comparison) — sourced from the
+        # central satellite registry so the date lives in one place.
+        _s1d_cutoff = SATELLITE_DATA_CUTOFFS.get("S1D")
+        S1D_CUTOFF = _s1d_cutoff.replace(tzinfo=None) if _s1d_cutoff else None
 
         for anomaly in list_anomalies:
             satellite = anomaly.get("impactedSatellite", "") or ""
@@ -270,7 +273,7 @@ class AnomaliesIngestor:
                             # already a datetime — strip timezone unconditionally
                             pub_dt = pub_date.replace(tzinfo=None)
 
-                        if pub_dt < S1D_CUTOFF:
+                        if S1D_CUTOFF and pub_dt < S1D_CUTOFF:
                             logger.debug(
                                 "[BACKFILL SKIP] S1D anomaly %s dated %s before cutoff, skipping",
                                 anomaly.get("key"), pub_dt

--- a/apps/ingestion/orbit_acquisitions.py
+++ b/apps/ingestion/orbit_acquisitions.py
@@ -20,6 +20,7 @@ import logging
 # from apps.elastic.modules.datatakes import OBSERVATION_START_KEY, OBSERVATION_END_KEY
 # from apps.elastic.modules.datatakes import DATATAKE_ID_KEY
 from apps.cache.modules.acquisitionassets import norad_id_map
+from apps.utils.satellite_registry import local_tle_files, get_mission_satellites
 from apps.ingestion.acquisition_plans.fragment_completeness import MissionDatatakeIdHandler
 from apps.ingestion.acquisition_plans.orbit_acquisitions_kml import OrbitAcquisitionKmlFragmentBuilder, \
     _build_datatake_placemark, build_acquisition_line_placemark, build_acquisition_polygon_placemark
@@ -29,11 +30,7 @@ from apps.utils.tle_fetcher import get_latest_tle
 
 logger = logging.getLogger(__name__)
 
-local_tle_files = {
-    "S3A": "S3A_20231012.tle",
-    "S3B": "S3B_20231017.tle",
-    "S5P": "S5P_20231017.tle",
-}
+# local_tle_files is sourced from apps.utils.satellite_registry (imported above).
 
 
 """ def get_latest_tle(satellite):
@@ -260,7 +257,13 @@ class AcquisitionPlanOrbitDatatakeBuilder:
                 )
 
 
-acq_orbit_mission_satellites = {"S3": ["S3A", "S3B"], "S5": ["S5P"]}
+# Orbit-based acquisition plans cover the S3 and S5 missions; derived from the
+# central registry so a new unit (e.g. S3C) is picked up automatically.
+acq_orbit_mission_satellites = {
+    m: sats
+    for m, sats in get_mission_satellites(active_only=True).items()
+    if m in ("S3", "S5")
+}
 
 def get_satellite_tle(satellite):
     norad_id = norad_id_map[satellite]

--- a/apps/routes/debug/routes.py
+++ b/apps/routes/debug/routes.py
@@ -28,6 +28,7 @@ import apps.utils.db_utils as db_utils
 import apps.utils.elastic_utils as elastic_utils
 from apps import flask_cache
 from apps.utils.date_utils import Quarter
+from apps.utils.satellite_registry import satellites_mission_map
 from . import blueprint
 
 logger = logging.getLogger(__name__)
@@ -51,14 +52,8 @@ mission_pub_extra_must_not_criteria = {
 
 fname_ends = {"S1": "SAFE.zip", "S2": "tar", "S3": "SEN3.zip", "S5": "nc"}
 
-platform_missions = {
-    "S1A": "S1",
-    "S2A": "S2",
-    "S2B": "S2",
-    "S3A": "S3",
-    "S3B": "S3",
-    "S5P": "S5",
-}
+# Satellite-unit → mission code, sourced from the central registry.
+platform_missions = satellites_mission_map
 
 
 @blueprint.route(

--- a/apps/routes/home/routes.py
+++ b/apps/routes/home/routes.py
@@ -74,6 +74,7 @@ import math
 import ast
 from zoneinfo import ZoneInfo
 from collections import defaultdict
+from apps.utils.satellite_registry import (ALLOWED_SATELLITES, SATELLITE_DISPLAY_NAMES, space_segment_colors, get_satellites_by_mission)
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +131,7 @@ PAGE_METADATA = {
         "title": "Sentinel Acquisition Plans & Real-Time Status | Copernicus Dashboard",
         "description": (
             "Explore past, current, and future Sentinel satellite acquisition plans on an interactive 3D globe. "
-            "Filter datatakes by mission, satellite, sensing mode, and date. Part of the official ESA Copernicus Sentinel Operations Dashboard.",
+            "Filter datatakes by mission, satellite, sensing mode, and date. Part of the official ESA Copernicus Sentinel Operations Dashboard."
         ),
         "page_keywords": [
             "Sentinel acquisition plans real-time map",
@@ -146,7 +147,7 @@ PAGE_METADATA = {
         "title": "Sentinel Mission Events & Anomalies | Copernicus Operations Dashboard",
         "description": (
             "Browse Sentinel satellite events including anomalies, calibrations, manoeuvres, and production issues from the past 3 months. "
-            "Understand how each event affects Copernicus data completeness and availability.",
+            "Understand how each event affects Copernicus data completeness and availability."
         ),
         "page_keywords": [
             "Sentinel satellite anomalies and events",
@@ -426,18 +427,6 @@ def index():
     segment = "index"
     period_id = "24h"
 
-    ALLOWED_SATELLITES = {
-        "S1A",
-        "S1C",
-        "S1D",
-        "S2A",
-        "S2B",
-        "S2C",
-        "S3A",
-        "S3B",
-        "S5P",
-    }
-
     # Build the cache key
     anomalies_api_uri = events_cache.anomalies_cache_key.format("last", period_id)
     current_app.logger.info(f"[INDEX] starting here")
@@ -491,18 +480,6 @@ def index():
 
     now = datetime.now(timezone.utc)
     anomalies_details = []
-
-    SATELLITE_DISPLAY_NAMES = {
-        "S1A": "Copernicus Sentinel-1A",
-        "S1C": "Copernicus Sentinel-1C",
-        "S1D": "Copernicus Sentinel-1D",
-        "S2A": "Copernicus Sentinel-2A",
-        "S2B": "Copernicus Sentinel-2B",
-        "S2C": "Copernicus Sentinel-2C",
-        "S3A": "Copernicus Sentinel-3A",
-        "S3B": "Copernicus Sentinel-3B",
-        "S5P": "Copernicus Sentinel-5P",
-    }
 
     for idx, item in enumerate(anomalies_data):
         if not isinstance(item, dict):
@@ -1056,7 +1033,7 @@ def data_availability():
             item_sat = (src.get("satellite_unit") or "").upper()
 
             if item_sat.startswith("S1"):
-                if item_sat not in ["S1A", "S1C", "S1D"]:
+                if item_sat not in ALLOWED_SATELLITES:
                     continue
 
             if event_datatake_ids:
@@ -1146,6 +1123,7 @@ def data_availability():
                 item_normalized["is_lightweight"] = True
                 datatakes_for_ssr.append(item_normalized)
 
+        satellites_by_mission = get_satellites_by_mission()
         payload = {
             "anomalies": replace_undefined(anomalies_data),
             "datatakes": datatakes_for_ssr,
@@ -1165,6 +1143,7 @@ def data_availability():
             "mission_counts": mission_counts,
             "event_id": event_id,
             "event_datatake_count": len(event_datatake_ids),
+            "satellites_by_mission":satellites_by_mission
         }
 
         current_app.logger.info(f"[LOG] Final SSR list size: {len(datatakes_for_ssr)}")
@@ -1768,18 +1747,6 @@ def admin_space_segment():
             "events": satellites[sat].get("events", {}),
         }
         for sat in satellites
-    }
-
-    space_segment_colors = {
-        "S1A": "info",
-        "S1C": "info",
-        "S1D": "info",
-        "S2A": "success",
-        "S2B": "success",
-        "S2C": "success",
-        "S3A": "warning",
-        "S3B": "warning",
-        "S5P": "secondary",
     }
 
     prev_quarter_label = acquisitions_utils.previous_quarter_label()

--- a/apps/static/assets/js/acquisition-plans/acquisition-plans.js
+++ b/apps/static/assets/js/acquisition-plans/acquisition-plans.js
@@ -28,12 +28,22 @@ missionDatatakeId = {
     'S5': "datatake_id"
 }
 
-satelliteNoradId = {
-    'S1A': 39634, 'S1B': 41456, 'S1C': 62261, 'S1D': 66315,
-    'S2A': 40697, 'S2B': 42063, 'S2C': 60989,
-    'S3A': 41335, 'S3B': 43437,
-    'S5P': 42969
-};
+// NORAD ids sourced from the central satellite registry (window.SATELLITE_DATA).
+satelliteNoradId = (function () {
+    var out = {};
+    var data = (window.SATELLITE_DATA && window.SATELLITE_DATA.satellites) || {};
+    for (var id in data) {
+        if (data[id].noradId != null) {
+            out[id] = data[id].noradId;
+        }
+    }
+    return Object.keys(out).length ? out : {
+        'S1A': 39634, 'S1B': 41456, 'S1C': 62261, 'S1D': 66315,
+        'S2A': 40697, 'S2B': 42063, 'S2C': 60989,
+        'S3A': 41335, 'S3B': 43437,
+        'S5P': 42969
+    };
+})();
 
 useDatePicker = false;
 
@@ -53,18 +63,26 @@ class MissionAcquisitionDates extends EventTarget {
 
         super();
 
-        this.acqplansDates = {
-            'S1A': { label: 'Sentinel-1A', mission: 'S1', dates: [] },
-            'S1B': { label: 'Sentinel-1B', mission: 'S1', dates: [] },
-            'S1C': { label: 'Sentinel-1C', mission: 'S1', dates: [] },
-            'S1D': { label: 'Sentinel-1D', mission: 'S1', dates: [] },
-            'S2A': { label: 'Sentinel-2A', mission: 'S2', dates: [] },
-            'S2B': { label: 'Sentinel-2B', mission: 'S2', dates: [] },
-            'S2C': { label: 'Sentinel-2C', mission: 'S2', dates: [] },
-            'S3A': { label: 'Sentinel-3A', mission: 'S3', dates: [] },
-            'S3B': { label: 'Sentinel-3B', mission: 'S3', dates: [] },
-            'S5P': { label: 'Sentinel-5P', mission: 'S5', dates: [] },
-        };
+        // Built from the central satellite registry (window.SATELLITE_DATA).
+        this.acqplansDates = (function () {
+            var out = {};
+            var data = (window.SATELLITE_DATA && window.SATELLITE_DATA.satellites) || {};
+            for (var id in data) {
+                out[id] = { label: data[id].label, mission: data[id].mission, dates: [] };
+            }
+            return Object.keys(out).length ? out : {
+                'S1A': { label: 'Sentinel-1A', mission: 'S1', dates: [] },
+                'S1B': { label: 'Sentinel-1B', mission: 'S1', dates: [] },
+                'S1C': { label: 'Sentinel-1C', mission: 'S1', dates: [] },
+                'S1D': { label: 'Sentinel-1D', mission: 'S1', dates: [] },
+                'S2A': { label: 'Sentinel-2A', mission: 'S2', dates: [] },
+                'S2B': { label: 'Sentinel-2B', mission: 'S2', dates: [] },
+                'S2C': { label: 'Sentinel-2C', mission: 'S2', dates: [] },
+                'S3A': { label: 'Sentinel-3A', mission: 'S3', dates: [] },
+                'S3B': { label: 'Sentinel-3B', mission: 'S3', dates: [] },
+                'S5P': { label: 'Sentinel-5P', mission: 'S5', dates: [] },
+            };
+        })();
 
         this.selectedParams = {
             'mission': null,

--- a/apps/static/assets/js/datatakes/datatakes.js
+++ b/apps/static/assets/js/datatakes/datatakes.js
@@ -258,6 +258,21 @@ class Datatakes {
         return (datatake_id + ' (' + hexaNum + ')');
     }
 
+    getGroundStation(id) {
+        var registry = window.SATELLITE_REGISTRY || {};
+        for (var mission in registry) {
+            var sats = registry[mission];
+            for (var i = 0; i < sats.length; i++) {
+                if (id.includes(sats[i])) {
+                    // "S5" → "Sentinel 5P", everything else → "Sentinel 1", "Sentinel 2", etc.
+                    var missionNumber = mission.substring(1);  // "1", "2", "3", "5"
+                    return mission === "S5" ? "Sentinel 5P" : "Sentinel " + missionNumber;
+                }
+            }
+        }
+        return "Sentinel";
+    }
+
     populateDataList(append = false) {
         this.showSpinner();
     }

--- a/apps/static/assets/js/events/calendar.js
+++ b/apps/static/assets/js/events/calendar.js
@@ -68,12 +68,21 @@ class CalendarWidget {
         this.selectedMission = 'all';
         this.selectedEventType = 'all';
         this.searchTerm = '';
-        this.missionMap = {
-            's1': ['S1A', 'S1C', 'S1D'],
-            's2': ['S2A', 'S2B', 'S2C'],
-            's3': ['S3A', 'S3B'],
-            's5': ['S5P']
-        };
+        // Derived from the central satellite registry (window.SATELLITE_DATA);
+        // keys are lowercased mission codes to match the existing filter logic.
+        this.missionMap = (function () {
+            var by = (window.SATELLITE_DATA && window.SATELLITE_DATA.byMission) || {};
+            var out = {};
+            for (var m in by) {
+                out[m.toLowerCase()] = by[m];
+            }
+            return Object.keys(out).length ? out : {
+                's1': ['S1A', 'S1C', 'S1D'],
+                's2': ['S2A', 'S2B', 'S2C'],
+                's3': ['S3A', 'S3B'],
+                's5': ['S5P']
+            };
+        })();
 
         this.eventTypeMap = {
             'Acquisition': 'acquisition',
@@ -818,12 +827,7 @@ class CalendarWidget {
         const events = (this.anomaliesByDate && this.anomaliesByDate[targetDate]) ? this.anomaliesByDate[targetDate] : [];
 
         const searchLower = (searchText || '').toLowerCase().trim();
-        const missionMap = this.missionMap || {
-            's1': ['S1A', 'S1C', 'S1D'],
-            's2': ['S2A', 'S2B', 'S2C'],
-            's3': ['S3A', 'S3B'],
-            's5': ['S5P']
-        };
+        const missionMap = this.missionMap;
         return events.filter(event => {
             if (['archive', 'data access', 'data-access'].includes((event.category || '').toLowerCase())) {
                 return false;
@@ -982,7 +986,8 @@ class CalendarWidget {
         if (!envStr) return '';
         if (envStr.includes('Data access')) return 'All Sentinels';
 
-        const sats = ['S1A', 'S1C', 'S1D', 'S2A', 'S2B', 'S2C', 'S3A', 'S3B', 'S5P'];
+        const sats = (window.SATELLITE_DATA && window.SATELLITE_DATA.active) ||
+            ['S1A', 'S1C', 'S1D', 'S2A', 'S2B', 'S2C', 'S3A', 'S3B', 'S5P'];
         return sats.filter(sat => envStr.includes(sat)).join(', ');
     }
 

--- a/apps/static/assets/js/events/timeline.js
+++ b/apps/static/assets/js/events/timeline.js
@@ -254,27 +254,14 @@ class Timeline {
         if (anomaly["category"] === "Data access") {
             item = "All Sentinels";
         } else {
-            if (anomaly["environment"].includes('S1A')) {
-                item += "S1A, "
-            }
-            if (anomaly["environment"].includes('S2A')) {
-                item += "S2A, "
-            }
-            if (anomaly["environment"].includes('S2B')) {
-                item += "S2B, "
-            }
-            if (anomaly["environment"].includes('S2C')) {
-                item += "S2C, "
-            }
-            if (anomaly["environment"].includes('S3A')) {
-                item += "S3A, "
-            }
-            if (anomaly["environment"].includes('S3B')) {
-                item += "S3B, "
-            }
-            if (anomaly["environment"].includes('S5P')) {
-                item += "S5P, "
-            }
+            // Active satellites from the central registry (window.SATELLITE_DATA).
+            var sats = (window.SATELLITE_DATA && window.SATELLITE_DATA.active) ||
+                ['S1A', 'S1C', 'S1D', 'S2A', 'S2B', 'S2C', 'S3A', 'S3B', 'S5P'];
+            sats.forEach(function (sat) {
+                if (anomaly["environment"].includes(sat)) {
+                    item += sat + ", ";
+                }
+            });
             item = item.substring(0, item.length - 2);
         }
 

--- a/apps/static/assets/js/quarterly-reports/space-segment.js
+++ b/apps/static/assets/js/quarterly-reports/space-segment.js
@@ -13,6 +13,21 @@ delivered to him.
 
 class SpaceSegment {
 
+    // Active satellite IDs from the central registry (window.SATELLITE_DATA),
+    // with a hardcoded fallback if the registry was not injected.
+    static _activeSatellites() {
+        return (window.SATELLITE_DATA && window.SATELLITE_DATA.active) ||
+            ['S1A', 'S1C', 'S1D', 'S2A', 'S2B', 'S2C', 'S3A', 'S3B', 'S5P'];
+    }
+
+    // Fresh { satId: [] } map keyed by every active satellite.
+    static _emptyDatatakesBySatellite() {
+        return SpaceSegment._activeSatellites().reduce(function (acc, s) {
+            acc[s] = [];
+            return acc;
+        }, {});
+    }
+
     constructor() {
 
         // Start - stop time range
@@ -31,22 +46,25 @@ class SpaceSegment {
             "#ff00cc", "#f57d05", "#fa001d"
         ];
 
-        // Set of colors associated to satellite
-        this.satUnavailabilitiesColorMap = {
-            'S1A': 'info',
-            'S1C': 'info',
-            'S2A': 'success',
-            'S2B': 'success',
-            'S2C': 'success',
-            'S3A': 'warning',
-            'S3B': 'warning',
-            'S5P': 'secondary'
-        };
+        // Bootstrap color class per satellite, sourced from the central
+        // registry (window.SATELLITE_DATA) — active satellites only.
+        this.satUnavailabilitiesColorMap = (function () {
+            var out = {};
+            var data = (window.SATELLITE_DATA && window.SATELLITE_DATA.satellites) || {};
+            for (var id in data) {
+                if (data[id].active) {
+                    out[id] = data[id].colorClass;
+                }
+            }
+            return Object.keys(out).length ? out : {
+                'S1A': 'info', 'S1C': 'info',
+                'S2A': 'success', 'S2B': 'success', 'S2C': 'success',
+                'S3A': 'warning', 'S3B': 'warning', 'S5P': 'secondary'
+            };
+        })();
 
         this.satUnavailabilities = {};
-        this.impactedDatatakesBySatellite = {
-            'S1A': [], 'S1C': [], 'S1D': [], 'S2A': [], 'S2B': [], 'S2C': [], 'S3A': [], 'S3B': [], 'S5P': []
-        };
+        this.impactedDatatakesBySatellite = SpaceSegment._emptyDatatakesBySatellite();
         this.impactedDatatakesTablesBySatellite = {};
         this.satellites = {}; // To store SENSING_DATA.stats
     }
@@ -91,9 +109,7 @@ class SpaceSegment {
     }
 
     loadDatatakesFromSSR(datatakes) {
-        this.impactedDatatakesBySatellite = {
-            'S1A': [], 'S1C': [], 'S1D': [], 'S2A': [], 'S2B': [], 'S2C': [], 'S3A': [], 'S3B': [], 'S5P': []
-        };
+        this.impactedDatatakesBySatellite = SpaceSegment._emptyDatatakesBySatellite();
 
         const stats = window.SENSING_DATA.stats || {};
 
@@ -470,7 +486,7 @@ class SpaceSegment {
     refreshDatatakesTablesSSR() {
         console.log("[SSR] Rendering impacted datatakes tables using DataTables");
 
-        const sats = ['S1A', 'S1C', 'S1D', 'S2A', 'S2B', 'S2C', 'S3A', 'S3B', 'S5P'];
+        const sats = SpaceSegment._activeSatellites();
 
         sats.forEach(sat => {
             const tableId = `${sat.toLowerCase()}-impacted-datatakes-table`;

--- a/apps/static/assets/js/utils.js
+++ b/apps/static/assets/js/utils.js
@@ -370,6 +370,17 @@ function get_mission_colors() {
     }
 }
 function get_satellite_colors() {
+    // Sourced from the central satellite registry (window.SATELLITE_DATA,
+    // injected on every page from apps/utils/satellite_registry.py).
+    var data = window.SATELLITE_DATA && window.SATELLITE_DATA.satellites;
+    if (data) {
+        var colors = {};
+        for (var id in data) {
+            colors[id] = data[id].chartColor;
+        }
+        return colors;
+    }
+    // Fallback if the registry was not injected on this page.
     return {
         'S1A': "#1d7af3",
         'S1B': "#3399ff",

--- a/apps/templates/home/data-availability.html
+++ b/apps/templates/home/data-availability.html
@@ -159,20 +159,13 @@
 
 											<select id="satellite-select" name="satellite" class="form-control" onchange="this.form.submit()">
 												<option value="">All Satellites</option>
-												{% if not mission or mission == 'S1' %}
-													<option value="S1A" {{ 'selected' if request.args.get('satellite')|upper == 'S1A' }}>S1A</option>
-													<option value="S1C" {{ 'selected' if request.args.get('satellite')|upper =='S1C' }}>S1C</option>
-													<option value="S1D" {{ 'selected' if request.args.get('satellite')|upper =='S1D' }}>S1D</option>
-												{% endif %}
-												{% if not mission or mission == 'S2' %}
-													<option value="S2A" {{ 'selected' if request.args.get('satellite')|upper =='S2A' }}>S2A</option>
-													<option value="S2B" {{ 'selected' if request.args.get('satellite')|upper =='S2B' }}>S2B</option>
-													<option value="S2C" {{ 'selected' if request.args.get('satellite')|upper =='S2C' }}>S2C</option>
-												{% endif %}
-												{% if not mission or mission == 'S3' %}
-													<option value="S3A" {{ 'selected' if request.args.get('satellite')|upper =='S3A' }}>S3A</option>
-													<option value="S3B" {{ 'selected' if request.args.get('satellite')|upper =='S3B' }}>S3B</option>
-												{% endif %}
+												{% for m, sats in satellites_by_mission.items() %}
+													{% if not mission or mission == m %}
+														{% for sat_id in sats %}
+														<option value="{{ sat_id }}" {{ 'selected' if request.args.get('satellite')|upper == sat_id }}>{{ sat_id }}</option>
+														{% endfor %}
+													{% endif %}
+												{% endfor %}
 											</select>
 
 											<div class="d-flex flex-column gap-2">
@@ -486,6 +479,9 @@
 	<!-- Datatables -->
 	<script src="/static/assets/js/plugin/datatables/datatables.min.js"></script>
 
+	<script>
+		window.SATELLITE_REGISTRY = {{ satellites_by_mission | tojson}};
+	</script>
 	<!-- Page related JS Class -->
 	<script src="/static/assets/js/datatakes/datatakes.js"></script>
 	<script id="server-data" type="application/json">

--- a/apps/templates/layouts/base-responsive.html
+++ b/apps/templates/layouts/base-responsive.html
@@ -22,6 +22,14 @@
   		{% endif %}
 	</script>
 
+	<!-- Centralized satellite registry — single source of truth:
+	     apps/utils/satellite_registry.py (injected via inject_satellite_registry) -->
+	<script>
+		window.SATELLITE_DATA = {{ satellite_registry_js | tojson }};
+		// Backwards-compatible alias: { mission: [sat_ids] } for active satellites
+		window.SATELLITE_REGISTRY = window.SATELLITE_DATA.byMission;
+	</script>
+
 	<!-- Fonts and icons -->
 	<script src="/static/assets/js/plugin/webfont/webfont.min.js" defer onload="
 		WebFont.load({

--- a/apps/utils/acquisitions_utils.py
+++ b/apps/utils/acquisitions_utils.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from datetime import date, datetime as dt, timezone, timedelta
 from flask_login import current_user
 from dateutil.relativedelta import relativedelta
+from apps.utils.satellite_registry import SATELLITE_INFO, SATELLITE_DATA_CUTOFFS, satellites_mission_map
 import datetime
 
 
@@ -18,18 +19,6 @@ STATION_MAP = {
     "MPS": "maspalomas",  # Maspalomas
     "NSG": "neustrelitz",  # Neustrelitz
     "INS": "inuvik",  # Inuvik
-}
-
-SATELLITE_INFO = {
-    "S1A": ("Copernicus Sentinel-1A", ["SAR", "PDHT", "OCP", "EDDS"]),
-    "S1C": ("Copernicus Sentinel-1C", ["SAR", "PDHT", "OCP", "EDDS"]),
-    "S1D": ("Copernicus Sentinel-1D", ["SAR", "PDHT", "OCP", "EDDS"]),
-    "S2A": ("Copernicus Sentinel-2A", ["MSI", "MMFU", "OCP", "EDDS", "STR"]),
-    "S2B": ("Copernicus Sentinel-2B", ["MSI", "MMFU", "OCP", "EDDS", "STR"]),
-    "S2C": ("Copernicus Sentinel-2C", ["MSI", "MMFU", "OCP", "EDDS", "STR"]),
-    "S3A": ("Copernicus Sentinel-3A", ["OLCI", "SLSTR", "SRAL", "MWR", "EDDS"]),
-    "S3B": ("Copernicus Sentinel-3B", ["OLCI", "SLSTR", "SRAL", "MWR", "EDDS"]),
-    "S5P": ("Copernicus Sentinel-5P", ["TROPOMI", "EDDS"]),
 }
 
 SERVICES = [
@@ -358,10 +347,9 @@ def build_space_segment_ssr(datatakes, unavailability, period_start, period_end)
     satellites = {}
     JS_THRESHOLD = 0.9999
 
+    # SATELLITE_INFO is derived from the registry's active satellites only,
+    # so decommissioned units (e.g. S1B) are already excluded.
     for sat, (fullname, instruments_list) in SATELLITE_INFO.items():
-        if sat == "S1B":
-            continue
-
         table_datatakes = []
         totSensing = 0.0
         failedSensingAcq = 0.0
@@ -601,7 +589,7 @@ def compute_availability_single_sat(
             availability["TROPOMI"] -= impact_pct
 
         # S3 Mission Instrument Logic (Looking into comments)
-        elif satellite in ("S3A", "S3B"):
+        elif satellites_mission_map.get(satellite) == "S3":
             for inst_name in ["OLCI", "SLSTR", "SRAL", "MWR"]:
                 if inst_name in availability and inst_name in comment:
                     availability[inst_name] -= impact_pct
@@ -1026,10 +1014,6 @@ def compute_availability_from_events(interface_status_map, period_start, period_
 
     return availability
 
-SATELLITE_DATA_CUTOFFS = {
-    "S1D": dt(2026, 4, 17, tzinfo=timezone.utc),
-}
-
 def passes_satellite_cutoff(record, date_field):
     """
     Returns True if this record should be kept.
@@ -1050,4 +1034,3 @@ def passes_satellite_cutoff(record, date_field):
         return True
 
     return ts_dt >= cutoff
-

--- a/apps/utils/satellite_registry.py
+++ b/apps/utils/satellite_registry.py
@@ -1,0 +1,494 @@
+"""
+Centralized Satellite Registry
+===============================
+Single source of truth for every satellite-level constant used across SentiBoard.
+
+Usage:
+    from apps.utils.satellite_registry import (
+        SATELLITES,
+        sat_ids,
+        norad_id_map,
+        ALLOWED_SATELLITES,
+        SATELLITE_DISPLAY_NAMES,
+        # ... any other derived lookup you need
+    )
+
+Adding a new satellite (e.g. S3C):
+    1. Add one entry to the SATELLITES dict below.
+    2. Everything else is derived automatically.
+    3. If the satellite is not yet launched, set norad_id=None and active=False.
+"""
+
+from datetime import datetime, timezone
+
+# ---------------------------------------------------------------------------
+# Primary registry — edit ONLY here when satellites change
+# ---------------------------------------------------------------------------
+#
+# Field reference:
+#   mission              mission code ("S1", "S2", "S3", "S5")
+#   display_name         full human-readable name
+#   norad_id             NORAD catalogue number (None pre-launch)
+#   instruments          list of instrument acronyms
+#   color_rgba           CZML / CesiumJS marker RGBA
+#   chart_color          hex color used by JS charts / legends
+#   marker_image         CesiumJS billboard image path
+#   ui_color_class       Bootstrap color class for space-segment cards
+#   acqplan_div          ESA acquisition-plan page div id (None if no plan)
+#   cds_key              lowercase key used to build CDS completeness indices
+#   time_threshold_hours datatake gap-detection threshold for the mission
+#   swath_width_km       orbit/datatake swath width in km (None if N/A)
+#   tle_file             local fallback TLE filename (None if N/A)
+#   data_cutoff          ISO date string; data before this is excluded (or None)
+#   active               True if currently operational
+#   has_acq_plan         True if the satellite has a published acquisition plan
+
+SATELLITES = {
+    # ── Sentinel-1 ──────────────────────────────────────────────────────────
+    "S1A": {
+        "mission": "S1",
+        "display_name": "Copernicus Sentinel-1A",
+        "norad_id": 39634,
+        "instruments": ["SAR", "PDHT", "OCP", "EDDS"],
+        "color_rgba": [72, 171, 247, 255],
+        "chart_color": "#1d7af3",
+        "marker_image": "static/assets/img/sentinel-1.png",
+        "ui_color_class": "info",
+        "acqplan_div": "sentinel-1a",
+        "cds_key": "s1a",
+        "time_threshold_hours": 8,
+        "swath_width_km": None,
+        "tle_file": None,
+        "data_cutoff": None,
+        "active": True,
+        "has_acq_plan": True,
+    },
+    "S1B": {
+        "mission": "S1",
+        "display_name": "Copernicus Sentinel-1B",
+        "norad_id": 41456,
+        "instruments": ["SAR", "PDHT", "OCP", "EDDS"],
+        "color_rgba": [72, 171, 247, 255],
+        "chart_color": "#3399ff",
+        "marker_image": "static/assets/img/sentinel-1.png",
+        "ui_color_class": "info",
+        "acqplan_div": None,
+        "cds_key": "s1b",
+        "time_threshold_hours": 8,
+        "swath_width_km": None,
+        "tle_file": None,
+        "data_cutoff": None,
+        "active": False,           # decommissioned
+        "has_acq_plan": False,
+    },
+    "S1C": {
+        "mission": "S1",
+        "display_name": "Copernicus Sentinel-1C",
+        "norad_id": 62261,
+        "instruments": ["SAR", "PDHT", "OCP", "EDDS"],
+        "color_rgba": [72, 171, 247, 255],
+        "chart_color": "#41aade",
+        "marker_image": "static/assets/img/sentinel-1.png",
+        "ui_color_class": "info",
+        "acqplan_div": "sentinel-1c",
+        "cds_key": "s1c",
+        "time_threshold_hours": 8,
+        "swath_width_km": None,
+        "tle_file": None,
+        "data_cutoff": None,
+        "active": True,
+        "has_acq_plan": True,
+    },
+    "S1D": {
+        "mission": "S1",
+        "display_name": "Copernicus Sentinel-1D",
+        "norad_id": 66315,
+        "instruments": ["SAR", "PDHT", "OCP", "EDDS"],
+        "color_rgba": [72, 171, 247, 255],
+        "chart_color": "#49c6df",
+        "marker_image": "static/assets/img/sentinel-1.png",
+        "ui_color_class": "info",
+        "acqplan_div": "sentinel-1d",
+        "cds_key": "s1d",
+        "time_threshold_hours": 8,
+        "swath_width_km": None,
+        "tle_file": None,
+        "data_cutoff": "2026-04-17",  # operational cutoff
+        "active": True,
+        "has_acq_plan": True,
+    },
+
+    # ── Sentinel-2 ──────────────────────────────────────────────────────────
+    "S2A": {
+        "mission": "S2",
+        "display_name": "Copernicus Sentinel-2A",
+        "norad_id": 40697,
+        "instruments": ["MSI", "MMFU", "OCP", "EDDS", "STR"],
+        "color_rgba": [49, 206, 54, 255],
+        "chart_color": "#59d05d",
+        "marker_image": "static/assets/img/sentinel-2.png",
+        "ui_color_class": "success",
+        "acqplan_div": "sentinel-2a",
+        "cds_key": "s2a",
+        "time_threshold_hours": 10,
+        "swath_width_km": None,
+        "tle_file": None,
+        "data_cutoff": None,
+        "active": True,
+        "has_acq_plan": True,
+    },
+    "S2B": {
+        "mission": "S2",
+        "display_name": "Copernicus Sentinel-2B",
+        "norad_id": 42063,
+        "instruments": ["MSI", "MMFU", "OCP", "EDDS", "STR"],
+        "color_rgba": [49, 206, 54, 255],
+        "chart_color": "#3fae3e",
+        "marker_image": "static/assets/img/sentinel-2.png",
+        "ui_color_class": "success",
+        "acqplan_div": "sentinel-2b",
+        "cds_key": "s2b",
+        "time_threshold_hours": 10,
+        "swath_width_km": None,
+        "tle_file": None,
+        "data_cutoff": None,
+        "active": True,
+        "has_acq_plan": True,
+    },
+    "S2C": {
+        "mission": "S2",
+        "display_name": "Copernicus Sentinel-2C",
+        "norad_id": 60989,
+        "instruments": ["MSI", "MMFU", "OCP", "EDDS", "STR"],
+        "color_rgba": [49, 206, 54, 255],
+        "chart_color": "#1cae5a",
+        "marker_image": "static/assets/img/sentinel-2.png",
+        "ui_color_class": "success",
+        "acqplan_div": "sentinel-2c",
+        "cds_key": "s2c",
+        "time_threshold_hours": 10,
+        "swath_width_km": None,
+        "tle_file": None,
+        "data_cutoff": None,
+        "active": True,
+        "has_acq_plan": True,
+    },
+
+    # ── Sentinel-3 ──────────────────────────────────────────────────────────
+    "S3A": {
+        "mission": "S3",
+        "display_name": "Copernicus Sentinel-3A",
+        "norad_id": 41335,
+        "instruments": ["OLCI", "SLSTR", "SRAL", "MWR", "EDDS"],
+        "color_rgba": [255, 173, 70, 255],
+        "chart_color": "#f3545d",
+        "marker_image": "static/assets/img/sentinel-3.png",
+        "ui_color_class": "warning",
+        "acqplan_div": None,
+        "cds_key": "s3a",
+        "time_threshold_hours": 696,
+        "swath_width_km": 1270,
+        "tle_file": "S3A_20231012.tle",
+        "data_cutoff": None,
+        "active": True,
+        "has_acq_plan": False,
+    },
+    "S3B": {
+        "mission": "S3",
+        "display_name": "Copernicus Sentinel-3B",
+        "norad_id": 43437,
+        "instruments": ["OLCI", "SLSTR", "SRAL", "MWR", "EDDS"],
+        "color_rgba": [255, 173, 70, 255],
+        "chart_color": "#fdaf4b",
+        "marker_image": "static/assets/img/sentinel-3.png",
+        "ui_color_class": "warning",
+        "acqplan_div": None,
+        "cds_key": "s3b",
+        "time_threshold_hours": 696,
+        "swath_width_km": 1270,
+        "tle_file": "S3B_20231017.tle",
+        "data_cutoff": None,
+        "active": True,
+        "has_acq_plan": False,
+    },
+    # S3C — not yet launched; norad_id / tle_file will be set post-launch.
+    # Uncomment and set active=True (plus norad_id) when SentiBoard onboards S3C.
+    # "S3C": {
+    #     "mission": "S3",
+    #     "display_name": "Copernicus Sentinel-3C",
+    #     "norad_id": None,
+    #     "instruments": ["OLCI", "SLSTR", "SRAL", "MWR", "EDDS"],
+    #     "color_rgba": [255, 173, 70, 255],
+    #     "chart_color": "#c8df45",
+    #     "marker_image": "static/assets/img/sentinel-3.png",
+    #     "ui_color_class": "warning",
+    #     "acqplan_div": None,
+    #     "cds_key": "s3c",
+    #     "time_threshold_hours": 696,
+    #     "swath_width_km": 1270,
+    #     "tle_file": None,
+    #     "data_cutoff": None,
+    #     "active": False,
+    #     "has_acq_plan": False,
+    # },
+
+    # ── Sentinel-5P ─────────────────────────────────────────────────────────
+    "S5P": {
+        "mission": "S5",
+        "display_name": "Copernicus Sentinel-5P",
+        "norad_id": 42969,
+        "instruments": ["TROPOMI", "EDDS"],
+        "color_rgba": [104, 97, 206, 255],
+        "chart_color": "#8f00ff",
+        "marker_image": "static/assets/img/sentinel-5p.png",
+        "ui_color_class": "secondary",
+        "acqplan_div": None,
+        "cds_key": "s5p",
+        "time_threshold_hours": 48,
+        "swath_width_km": 2600,
+        "tle_file": "S5P_20231017.tle",
+        "data_cutoff": None,
+        "active": True,
+        "has_acq_plan": False,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Derived lookups — everything below is auto-generated from SATELLITES
+# ---------------------------------------------------------------------------
+
+# Mission display order used wherever satellites are grouped for the UI.
+MISSION_ORDER = ["S1", "S2", "S3", "S5"]
+
+
+def _active():
+    """Return satellite IDs where active=True."""
+    return [s for s, v in SATELLITES.items() if v["active"]]
+
+
+def _all_ids():
+    """Return all satellite IDs (active + inactive)."""
+    return list(SATELLITES.keys())
+
+
+def ids_for_mission(mission, active_only=True):
+    """Return the satellite IDs belonging to a mission (e.g. "S1")."""
+    return [
+        s
+        for s, v in SATELLITES.items()
+        if v["mission"] == mission and (not active_only or v["active"])
+    ]
+
+
+# ── acquisitionassets.py replacements ───────────────────────────────────────
+
+sat_ids = _active()
+"""Active satellite IDs used by the orbit loader and general iteration."""
+
+norad_id_map = {
+    s: v["norad_id"]
+    for s, v in SATELLITES.items()
+    if v["norad_id"] is not None       # safe for pre-launch satellites
+}
+"""NORAD catalogue numbers — excludes satellites without a TLE (e.g. S3C)."""
+
+color_map = {s: v["color_rgba"] for s, v in SATELLITES.items()}
+"""CZML / CesiumJS RGBA color per satellite."""
+
+marker_map = {s: v["marker_image"] for s, v in SATELLITES.items()}
+"""CesiumJS billboard image path per satellite."""
+
+chart_color_map = {s: v["chart_color"] for s, v in SATELLITES.items()}
+"""Hex chart/legend color per satellite (JS get_satellite_colors equivalent)."""
+
+
+# ── orbit ingestion replacements ────────────────────────────────────────────
+
+local_tle_files = {
+    s: v["tle_file"]
+    for s, v in SATELLITES.items()
+    if v.get("tle_file")
+}
+"""Local fallback TLE filenames per satellite."""
+
+swaths = {
+    s: v["swath_width_km"]
+    for s, v in SATELLITES.items()
+    if v.get("swath_width_km") is not None
+}
+"""Orbit/datatake swath widths (km) per satellite."""
+
+
+# ── datatakes.py replacements ──────────────────────────────────────────────
+
+satellites_mission_map = {s: v["mission"] for s, v in SATELLITES.items()}
+"""Map every satellite ID (including inactive) to its mission code."""
+
+mission_time_thresholds = {}
+for _s, _v in SATELLITES.items():
+    mission_time_thresholds.setdefault(_v["mission"], _v["time_threshold_hours"])
+"""Hours threshold per mission used in datatake gap detection."""
+
+CDS_MISSIONS = {}
+for _s, _v in SATELLITES.items():
+    if _v["active"]:
+        CDS_MISSIONS.setdefault(_v["mission"].lower(), []).append(_v["cds_key"])
+"""CDS index-building map: {"s1": ["s1a", "s1c", "s1d"], ...}"""
+
+
+# ── acquisitions_utils.py replacement ──────────────────────────────────────
+
+SATELLITE_INFO = {
+    s: (v["display_name"], v["instruments"])
+    for s, v in SATELLITES.items()
+    if v["active"]
+}
+"""(display_name, instruments) tuples for the space-segment page."""
+
+
+# ── routes.py replacements ─────────────────────────────────────────────────
+
+ALLOWED_SATELLITES = set(_active())
+"""Set of satellite IDs accepted by the home / data-availability filters."""
+
+SATELLITE_DISPLAY_NAMES = {
+    s: v["display_name"]
+    for s, v in SATELLITES.items()
+    if v["active"]
+}
+"""Human-readable names for UI labels and anomaly banners."""
+
+space_segment_colors = {
+    s: v["ui_color_class"]
+    for s, v in SATELLITES.items()
+    if v["active"]
+}
+"""Bootstrap color class per satellite for the space-segment cards."""
+
+
+# ── data_cutoff (used by SATELLITE_DATA_CUTOFFS in acquisitions_utils) ─────
+
+def _parse_cutoff(value):
+    """Parse an ISO ``YYYY-MM-DD`` cutoff string into a tz-aware datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+
+SATELLITE_DATA_CUTOFFS = {
+    s: _parse_cutoff(v["data_cutoff"])
+    for s, v in SATELLITES.items()
+    if v["data_cutoff"] is not None
+}
+"""Operational cutoff datetimes (tz-aware): data before this is excluded."""
+
+
+# ── config JSON replacements ──────────────────────────────────────────────
+
+def get_mission_satellites(active_only=True):
+    """
+    Build the mission_satellites dict that used to live in config-*.json.
+
+    Returns e.g. {"S1": ["S1A", "S1B", "S1C", "S1D"], "S2": [...], ...}
+
+    When active_only=True, inactive satellites are excluded — use this for
+    acq_plans_mission_satellites and any UI-facing list.
+    """
+    result = {}
+    for s, v in SATELLITES.items():
+        if active_only and not v["active"]:
+            continue
+        result.setdefault(v["mission"], []).append(s)
+    return result
+
+
+def get_acqplan_div_map():
+    """
+    Build the acqplan_div mapping for the acquisition-plans scraper.
+
+    Returns e.g. {"S1": {"S1A": "sentinel-1a", "S1C": "sentinel-1c", ...}, ...}
+    Only includes satellites with a non-None acqplan_div.
+    """
+    result = {}
+    for s, v in SATELLITES.items():
+        if v["active"] and v.get("acqplan_div"):
+            result.setdefault(v["mission"], {})[s] = v["acqplan_div"]
+    return result
+
+
+# ── JS / Jinja helpers ─────────────────────────────────────────────────────
+
+def get_satellites_by_mission(active_only=True):
+    """
+    Ordered dict of mission → [sat_ids] for Jinja template loops
+    (replaces hardcoded <option> tags in data-availability.html).
+
+    Returns e.g. OrderedDict([("S1", ["S1A","S1C","S1D"]), ("S2", [...]), ...])
+    """
+    from collections import OrderedDict
+
+    grouped = {}
+    for s, v in SATELLITES.items():
+        if active_only and not v["active"]:
+            continue
+        grouped.setdefault(v["mission"], []).append(s)
+
+    return OrderedDict((m, grouped[m]) for m in MISSION_ORDER if m in grouped)
+
+
+def get_ground_station_label(datatake_id):
+    """
+    JS getGroundStation() equivalent — returns a mission label from a datatake ID.
+
+    >>> get_ground_station_label("S1A_IW_20240601")
+    'Sentinel 1'
+    """
+    for s, v in SATELLITES.items():
+        if s in datatake_id:
+            mission_number = v["mission"][1:]       # "1", "2", "3", "5"
+            if v["mission"] == "S5":
+                return "Sentinel 5P"
+            return f"Sentinel {mission_number}"
+    return "Sentinel"
+
+
+def to_js_registry(active_only=False):
+    """
+    Serialize satellites as a JSON-safe payload for injection into a Jinja
+    <script> block (window.SATELLITE_DATA) or an /api/satellites endpoint.
+
+    Includes ALL satellites by default so JS can colour historical (e.g. S1B)
+    and pre-launch (e.g. S3C) data; filter on the ``active`` flag in JS when a
+    UI list should only show operational satellites.
+
+    Shape:
+        {
+          "satellites": { "S1A": {mission, displayName, label, colorClass,
+                                  chartColor, noradId, active, hasAcqPlan}, ... },
+          "byMission":  { "S1": ["S1A","S1C","S1D"], ... },   # active only
+          "active":     ["S1A", "S1C", ...],
+        }
+    """
+    satellites = {
+        s: {
+            "mission": v["mission"],
+            "displayName": v["display_name"],
+            # short label e.g. "Sentinel-1A" used by acquisition-plans.js
+            "label": v["display_name"].replace("Copernicus ", ""),
+            "colorClass": v["ui_color_class"],
+            "chartColor": v["chart_color"],
+            "noradId": v["norad_id"],
+            "active": v["active"],
+            "hasAcqPlan": v["has_acq_plan"],
+        }
+        for s, v in SATELLITES.items()
+        if v["active"] or not active_only
+    }
+    return {
+        "satellites": satellites,
+        "byMission": {m: sats for m, sats in get_satellites_by_mission().items()},
+        "active": _active(),
+    }


### PR DESCRIPTION
## Summary
Introduces `apps/utils/satellite_registry.py` as the single source of truth for
all satellite metadata (mission, NORAD id, colours, instruments, acq-plan divs,
CDS keys, thresholds, swath widths, TLE files, data cutoffs, active/decommissioned
state) and migrates every reachable consumer — Python, config-consumers, Jinja and
JS — to read from it instead of hardcoded lists. This makes onboarding a new
satellite (e.g. Sentinel-3C) a one-entry change.

## What changed
**Registry**
- New `satellite_registry.py`: one `SATELLITES` dict + derived lookups
  (`sat_ids`, `norad_id_map`, `color_map`, `chart_color_map`, `satellites_mission_map`,
  `CDS_MISSIONS`, `mission_time_thresholds`, `SATELLITE_INFO`, `ALLOWED_SATELLITES`,
  `SATELLITE_DISPLAY_NAMES`, `space_segment_colors`, `SATELLITE_DATA_CUTOFFS`,
  `swaths`, `local_tle_files`) and helpers (`ids_for_mission`, `get_mission_satellites`,
  `get_acqplan_div_map`, `get_satellites_by_mission`, `get_ground_station_label`,
  `to_js_registry`).
- S3C entry included, commented-out and ready to activate post-launch.

**Python backend** — hardcoded satellite lists removed in favour of registry lookups:
`acquisitions_utils.py`, `elastic/modules/datatakes.py`, `elastic/modules/archive_statistics.py`,
`routes/home/routes.py`, `routes/debug/routes.py`, `ingestion/anomalies_ingestor.py`,
`ingestion/orbit_acquisitions.py`, `ingestion/acquisition_plans/orbit_datatake_acquisitions.py`,
`ingestion/acquisition_plans/acq_link_page.py`, `ingestion/acq_plan_ingestor.py`,
`cache/modules/acquisitionassets.py`.

**Frontend** — app-wide context processor injects `window.SATELLITE_DATA` on every
page (via `layouts/base-responsive.html`); migrated `utils.js`, `acquisition-plans.js`,
`events/calendar.js`, `events/timeline.js`, `quarterly-reports/space-segment.js`, and the
data-availability satellite dropdown to read from it (each keeps a hardcoded fallback).

**Incidental fixes**
- `SATELLITE_DATA_CUTOFFS` now yields tz-aware datetimes (previously a string that
  would have crashed the `ts_dt >= cutoff` comparison).
- `routes.py` PAGE_METADATA `description` values were tuples (stray trailing commas);
  now proper strings.
- Removed a duplicate `[CDS][S1S2] Querying …` log and fixed a mislabeled
  `[ORIGIN_MAP]` log (logged "MP" inside the IPF/ADGS branch) — DEVOCS-205.

## Behaviour notes
- Space-segment colour map and the events timeline now include S1D / S1C where they
  were previously omitted (they now derive from the active-satellite list).
- The space-segment page's 9 per-satellite pie-chart blocks were intentionally left
  hardcoded (they have non-uniform labels); the availability cards above are already
  loop-driven.

## Not in this PR
- `config-prod.json` / `config-dev.json` are gitignored (they contain credentials).
  S3C is staged there locally under a `_pending_satellites` block for the deployment
  config, but that is environment-local by design.