### PR TITLE
Space-segment report fix for Satellite issues and acquisition issues undercounted

### DIFF
--- a/apps/ingestion/acquisition_plans/fragment_completeness.py
+++ b/apps/ingestion/acquisition_plans/fragment_completeness.py
@@ -223,10 +223,6 @@ class FragmentCompletenessHandler:
     def _set_completeness_day_list(self, day_list, sat_fragments, satellite):
         for acq_day in day_list:
             day_fragment = sat_fragments.get_fragment(acq_day)
-            before = len(day_fragment.placemark_list)
-            in_cache = self.daily_datatakes.get(acq_day) is not None
-            sat_in_cache = (in_cache and
-                        self.daily_datatakes.get(acq_day).get(satellite) is not None)
 
             try:
                 day_datatakes = self.daily_datatakes.get(acq_day)
@@ -246,9 +242,6 @@ class FragmentCompletenessHandler:
             except Exception as ex:
                 logger.error("COMPLETENESS FAILED sat=%s day=%s: %s",
                             satellite, acq_day, ex, exc_info=1)
-            after = len(day_fragment.placemark_list)
-            logger.warning("COMPLETENESS sat=%s day=%s in_cache=%s sat_in_cache=%s  %d -> %d",
-                       satellite, acq_day, in_cache, sat_in_cache, before, after)
 
     def _load_completeness_on_placemarks(self, completeness, id_prefix, placemarks):
         for pm in placemarks:

--- a/apps/routes/home/routes.py
+++ b/apps/routes/home/routes.py
@@ -1725,6 +1725,26 @@ def admin_space_segment():
         for dt in sat.get("datatakes", []):
             dt["completeness"] = acquisitions_utils.recalc_completeness(dt)
 
+    acq_key = acquisitions_cache.acquisitions_cache_key.format(cache_prefix, cache_range)
+    acq_sources = acquisitions_utils._cache_to_list(flask_cache.get(acq_key))
+    acq_stats = acquisitions_utils.compute_acquisition_stats(acq_sources)
+    for sat_id, sat_data in satellites.items():
+        a = acq_stats.get(sat_id)
+        if not a or a["total"] <= 0 or a["failed_acq"] <= 0:
+            continue
+        unavail = sat_data["unavailability"]
+        planned = (
+            sat_data["success"] + unavail["sat"] + unavail["acq"] + unavail["other"]
+        )
+        acq_hours = (a["failed_acq"] / a["total"]) * planned
+        unavail["acq"] += acq_hours
+        sat_data["success"] = max(
+            0.0, planned - (unavail["sat"] + unavail["acq"] + unavail["other"])
+        )
+        sat_data["events"]["acq_events"] = sorted(
+            a["events"].values(), key=lambda x: x["date"]
+        )
+
     for sat_id, sat_data in satellites.items():
 
         # Calculate % based on total planned hours vs success hours

--- a/apps/static/assets/js/quarterly-reports/space-segment.js
+++ b/apps/static/assets/js/quarterly-reports/space-segment.js
@@ -244,47 +244,53 @@ class SpaceSegment {
             return isNaN(d.getTime()) ? null : d;
         };
 
-        const periodStart = parseDate(startStr);
+        let periodStart = parseDate(startStr);
         const periodEnd = parseDate(endStr);
+
+        // Per-satellite operational cutoff: for S1D only consider events from its
+        // TTO date (17 Apr 2026), regardless of the selected quarter start.
+        const SAT_CUTOFFS = { 'S1D': '2026-04-17T00:00:00Z' };
+        const cutoff = parseDate(SAT_CUTOFFS[satellite]);
+        if (cutoff && (!periodStart || cutoff > periodStart)) {
+            periodStart = cutoff;
+        }
+
         const isRangeValid = !!(periodStart && periodEnd);
 
         var count = 0;
         var content = {};
         content.title = 'Unavailability events';
-        content.message = '<ul>';
-        var hasEvents = false;
 
-        // Use 'this' to access the class property
+        // Collect matching events first so we can sort them by occurrence date.
+        const events = [];
         Object.keys(this.satUnavailabilities).forEach((ref) => {
             var unav = this.satUnavailabilities[ref];
+            if (unav['satellite'] !== satellite || unav['item'] === 'EDDS') return;
 
-            if (unav['satellite'] === satellite && unav['item'] !== 'EDDS') {
+            const eventStart = new Date(unav.start);
+            const isWithinTime = !isRangeValid || (eventStart >= periodStart && eventStart <= periodEnd);
+            if (!isWithinTime) return;
 
-                // SSR Date Filter
-                const eventStart = new Date(unav.start);
-                const isWithinTime = !isRangeValid || (eventStart >= periodStart && eventStart <= periodEnd);
-
-                if (isWithinTime) {
-                    // Convert Seconds to Hours (matches your original code)
-                    var durationHours = unav['duration'] / (60 * 60);
-
-                    if (durationHours > 0.1) {
-                        hasEvents = true;
-                        var durationFormatted = durationHours.toFixed(1);
-
-                        // Exact string replication from your previous version
-                        content.message += '<li>Ref: ' + unav['reference'] + ' (' + unav['item'] + '); ' +
-                            'type: ' + unav['type'] + '; occurrence date: ' +
-                            unav['start'].replace('.000Z', '').replace('Z', '') +
-                            '; duration[h]: ' + durationFormatted + '</li>';
-                    } else {
-                        count++;
-                    }
-                }
+            // Convert Seconds to Hours (matches the original code)
+            const durationHours = unav['duration'] / (60 * 60);
+            if (durationHours > 0.1) {
+                events.push({
+                    start: eventStart,
+                    html: 'Ref: ' + unav['reference'] + ' (' + unav['item'] + '); ' +
+                        'type: ' + unav['type'] + '; occurrence date: ' +
+                        unav['start'].replace('.000Z', '').replace('Z', '') +
+                        '; duration[h]: ' + durationHours.toFixed(1)
+                });
+            } else {
+                count++;
             }
         });
 
-        content.message += '</ul>';
+        // Sort by occurrence date (ascending)
+        events.sort((a, b) => a.start - b.start);
+
+        var hasEvents = events.length > 0;
+        content.message = '<ul>' + events.map((e) => '<li>' + e.html + '</li>').join('') + '</ul>';
 
         // Footer logic for "No Events" or "Omitted"
         if (!hasEvents) {
@@ -472,9 +478,12 @@ class SpaceSegment {
 
             if (events.length > 0) {
                 content.message += 'Events list:<br /><ul>';
-                (Array.isArray(events) ? events : Object.values(events)).forEach(ev => {
-                    content.message += `<li>${ev.date}: ${ev.description}</li>`;
-                });
+                // Sort by date ascending (dates are ISO YYYY-MM-DD -> lexicographic = chronological)
+                (Array.isArray(events) ? events.slice() : Object.values(events))
+                    .sort((a, b) => (a.date || '').localeCompare(b.date || ''))
+                    .forEach(ev => {
+                        content.message += `<li>${ev.date}: ${ev.description}</li>`;
+                    });
                 content.message += '</ul>';
             }
         });

--- a/apps/utils/acquisitions_utils.py
+++ b/apps/utils/acquisitions_utils.py
@@ -30,6 +30,18 @@ SERVICES = [
     "WERUM",
 ]
 
+# Satellite subsystems (platform + instruments). An UNPLANNED unavailability on
+# any of these is counted as a "satellite issue" in the space-segment report,
+# matching the CAMS satellite-unavailability report. Ground-segment subsystems
+# (EDDS DARC, GFTS, External Server, MCS, ...) are intentionally excluded — those
+# belong to the acquisition service, not the satellite.
+SATELLITE_SUBSYSTEMS = {
+    # platform / payload
+    "SAR", "PDHT", "OCP", "AIS", "MMFU", "STR", "STR-1", "STR-2",
+    # instruments
+    "MSI", "OLCI", "SLSTR", "SRAL", "MWR", "TROPOMI",
+}
+
 
 def build_acquisition_payload(acquisitions, edrs_acquisitions, period_id=""):
     payload = {
@@ -301,6 +313,70 @@ def previous_quarter_label(today=None):
     return f"{start.strftime('%b')} - {end.strftime('%b %Y')}"
 
 
+def compute_acquisition_stats(acquisitions):
+    """
+    Per-satellite acquisition (downlink pass) failure stats, read from the
+    cds-cadip-acquisition-pass-status cache. A pass is "failed" when any of the
+    antenna / delivery-push / front-end statuses is not OK. We keep only failures
+    whose cams_origin is an acquisition-service cause ('Acquis'), since satellite
+    causes are already accounted for via the unavailability report and RFI/other
+    causes belong to the "Other" bucket.
+
+    Returns: {sat_id: {"total": int, "failed_acq": int, "events": {ref: event}}}
+    The caller converts failed_acq into "lost sensing hours" proportionally
+    (failed_acq / total * planned_sensing_hours), keeping the page's hour-based
+    accounting consistent.
+    """
+    stats = {}
+    for row in acquisitions or []:
+        src = row.get("_source", row) if isinstance(row, dict) else {}
+        sat = (src.get("satellite_id") or src.get("satellite_unit") or "")[:3].upper()
+        if not sat:
+            continue
+
+        # Apply the per-satellite operational cutoff (e.g. S1D from 17 Apr 2026)
+        # consistently with datatakes/unavailability: pre-TTO passes are excluded
+        # from BOTH the failed count and the total.
+        cutoff = SATELLITE_DATA_CUTOFFS.get(sat)
+        if cutoff is not None:
+            ts = src.get("planned_data_start")
+            if ts:
+                try:
+                    if dt.fromisoformat(ts.replace("Z", "+00:00")) < cutoff:
+                        continue
+                except (ValueError, TypeError):
+                    pass
+
+        s = stats.setdefault(sat, {"total": 0, "failed_acq": 0, "events": {}})
+        s["total"] += 1
+
+        ok = (
+            src.get("antenna_status") in (True, "OK")
+            and src.get("delivery_push_status") in (True, "OK")
+            and src.get("front_end_status") in (True, "OK")
+        )
+        if ok:
+            continue
+
+        if "Acquis" in (src.get("cams_origin") or ""):
+            s["failed_acq"] += 1
+            ref = (
+                src.get("last_attached_ticket")
+                or src.get("planned_data_start")
+                or f"{sat}-acq-{s['failed_acq']}"
+            )
+            station = src.get("ground_station") or "ground station"
+            desc = f"Acquisition issue at {station}"
+            if src.get("cams_description"):
+                desc += f". {src.get('cams_description')}"
+            s["events"][ref] = {
+                "date": (src.get("planned_data_start") or "0000-00-00")[:10],
+                "description": desc,
+                "type": "Acquisition",
+            }
+    return stats
+
+
 def build_space_segment_ssr(datatakes, unavailability, period_start, period_end):
     # print(f"\n--- DEBUG START ---")
     # print(f"Total Datatakes Received: {len(datatakes)}")
@@ -369,7 +445,7 @@ def build_space_segment_ssr(datatakes, unavailability, period_start, period_end)
         for datatake in current_dt_list:
             origin = datatake.get("cams_origin") or ""
 
-            compl_val = recalc_completeness(datatake)
+            compl_val = recalc_acq_completeness(datatake)
             ticket = datatake.get("last_attached_ticket")
 
             if not ticket and compl_val == 0.0:
@@ -437,35 +513,32 @@ def build_space_segment_ssr(datatakes, unavailability, period_start, period_end)
                     }
 
                     # --- Categorization Logic ---
+                    # Restored to match the original (pre-refactor) space-segment.js:
+                    # Acquisition is checked FIRST, then Satellite, then Other, using
+                    # the same case-sensitive substrings on the raw cams_origin value.
+                    # Acquisition origins also contain the "CAM"/CAMS token, so checking
+                    # Satellite first (as the refactor did) misclassified acquisition
+                    # issues as satellite issues (and zeroed out the acquisition figure).
                     category_key = "other_events"
                     issue_type_label = "Other"
 
-                    if "OCM" in desc_upper or any(
-                        x in origin_str for x in ["SAT", "CAM", "INSTRUMENT"]
-                    ):
-                        failedSensingSat += lost_hrs
-                        issue_type_label = "Satellite"
-                        category_key = "sat_events"
-
-                    # Acquisition Logic
-                    elif any(
-                        x in origin_str
-                        for x in ["ACQUIS", "X-BAND", "ANTENNA", "GROUND"]
-                    ) or any(x in desc_upper for x in ["FIBER", "NETWORK", "STATION"]):
+                    if "Acquis" in raw_origin:
                         failedSensingAcq += lost_hrs
                         issue_type_label = "Acquisition"
                         category_key = "acq_events"
 
-                    # Other Logic
+                    elif "CAM" in raw_origin or "Sat" in raw_origin:
+                        # Satellite issues are re-sourced from the UNPLANNED
+                        # unavailability records after this loop (see below), so
+                        # skip the datatake-level satellite signal here to avoid
+                        # double-counting. The datatake itself still appears in the
+                        # impacted-datatakes table (built separately).
+                        continue
+
                     else:
                         failedSensingOther += lost_hrs
+                        issue_type_label = "Other"
                         category_key = "other_events"
-                        if "RFI" in desc_upper:
-                            issue_type_label = "RFI"
-                        elif "PRODUCTION" in desc_upper:
-                            issue_type_label = "Production"
-                        else:
-                            issue_type_label = "Other"
 
                     display_label = raw_origin if raw_origin else issue_type_label
                     formatted_description = f"{display_label} issue. {final_desc}"
@@ -485,6 +558,44 @@ def build_space_segment_ssr(datatakes, unavailability, period_start, period_end)
             #    print(
             #        f"DEBUG [{sat}]: Ignoring Ticket {ticket} because completeness is {compl_val}%"
             #    )
+
+        # --- Satellite issues: sourced from the UNPLANNED satellite-subsystem
+        # unavailability records (SAR/PDHT/OCP/instruments), grouped by
+        # unavailability_reference. This matches the CAMS satellite-unavailability
+        # report (S1A = 4, S1C = 2, S1D = 2 for Apr-Jun 2026), which the datatake
+        # /L0 signal alone cannot reproduce (recovered downlinks leave L0 at 100%).
+        # A single reference has one row per affected subsystem sharing the same
+        # duration, so we de-duplicate by reference. Hours use the unavailability
+        # duration (microseconds -> hours), matching the CAMS report's durations.
+        sat_unavail_events = {}
+        for u in unavail_by_sat.get(sat, []):
+            if (u.get("type") or "").strip().lower() != "unplanned":
+                continue
+            subsystem = (u.get("subsystem") or u.get("instrument") or "").upper()
+            if subsystem not in SATELLITE_SUBSYSTEMS:
+                continue
+            ref = u.get("unavailability_reference") or u.get("key")
+            if not ref or ref in sat_unavail_events:
+                continue
+            dur_h = (u.get("unavailability_duration") or 0) / 3_600_000_000.0
+            comment = u.get("comment") or u.get("cams_description") or ""
+            desc = f"{subsystem} unavailability {ref}"
+            if comment:
+                desc += f". {comment}"
+            sat_unavail_events[ref] = {
+                "hours": dur_h,
+                "date": (u.get("start_time") or "0000-00-00")[:10],
+                "description": desc,
+                "type": "Satellite",
+            }
+
+        failedSensingSat = sum(e["hours"] for e in sat_unavail_events.values())
+        # Replace any datatake-derived satellite events with the unavailability
+        # ones (drop the internal "hours" helper key before exposing them).
+        categorized_events["sat_events"] = {
+            ref: {k: v for k, v in e.items() if k != "hours"}
+            for ref, e in sat_unavail_events.items()
+        }
 
         totSuccessSensing = totSensing - (
             failedSensingAcq + failedSensingSat + failedSensingOther
@@ -710,6 +821,28 @@ def build_sensing_statistics(datatakes, completeness_threshold=0.99):
     data["categorizedAnomalies"] = categorizedAnomalies
 
     return data
+
+
+def recalc_acq_completeness(datatake):
+    """
+    Faithful port of the original space-segment.js recalcDatatakeAcqCompleteness():
+    return the first *truthy* value among L0_ -> L1_ -> L2_, else 0.0.
+
+    Unlike recalc_completeness(), this does NOT fall back to
+    final_completeness_percentage. That fallback made anomalous datatakes (whose
+    L0_ was low/absent but whose PUB percentage was high) read as ~100% complete,
+    hiding their lost sensing hours from the space-segment statistics.
+    """
+    for key in ("L0_", "L1_", "L2_"):
+        val = datatake.get(key)
+        if val:  # truthy -> matches the original JS (0 / None / "" are skipped)
+            try:
+                if isinstance(val, str):
+                    val = val.replace("%", "").strip()
+                return float(val)
+            except (ValueError, TypeError):
+                continue
+    return 0.0
 
 
 def recalc_completeness(datatake):


### PR DESCRIPTION
Satellite and acquisition issues were previously derived only from datatake L0 completeness, which cannot reflect satellite unavailabilities or acquisition-service failures — so satellite issues were undercounted, acquisition always showed 0%, and recovered outages (e.g. S1C) appeared as 100%. Satellite issues are now taken from the satellite-unavailability report (counts and durations match CAMS exactly), and acquisition issues from the acquisition-pass dataset.