### PR TITLE
Feature opsocs 915 acquisition impact filter - populate impacted-datatakes table from anomaly

### DIFF
--- a/apps/routes/home/routes.py
+++ b/apps/routes/home/routes.py
@@ -1824,6 +1824,29 @@ def admin_space_segment():
         for _d in datatakes_sources
         if _d.get("datatake_id")
     }
+
+    # Satellite issues are re-sourced from this same anomaly join (matching the
+    # events page): a Platform-category anomaly with >=1 L0-impacted datatake in
+    # the period. Hours = the datatakes' actual L0-lost hours. This supersedes the
+    # unavailability-based figure computed in build_space_segment_ssr, so the popup,
+    # the impacted-DT table and the events page are all consistent.
+    _sat_hours = {}
+    _sat_events = {}  # sat -> {anomaly_key: event}
+
+    def _dt_hours(dt):
+        dur = dt.get("l0_sensing_duration")
+        if dur:
+            return dur / 3_600_000_000.0
+        s, e = dt.get("observation_time_start"), dt.get("observation_time_stop")
+        if s and e:
+            try:
+                return (
+                    datetime.fromisoformat(e.replace("Z", "+00:00"))
+                    - datetime.fromisoformat(s.replace("Z", "+00:00"))
+                ).total_seconds() / 3600.0
+            except (ValueError, TypeError):
+                return 0.0
+        return 0.0
     for _anom in (anomalies_model.get_anomalies() or []):
         _raw = _anom.datatakes_completeness
         if not _raw:
@@ -1859,7 +1882,38 @@ def admin_space_segment():
                 _origin, _anom.key, _compl,
             )
 
+            # Accumulate satellite issues from Platform-category anomalies.
+            if _anom.category == "Platform" and _sat in stats:
+                _sat_hours[_sat] = _sat_hours.get(_sat, 0.0) + _dt_hours(_dt) * (
+                    1.0 - _compl / 100.0
+                )
+                _date = (_dt.get("observation_time_start") or "0000-00-00")[:10]
+                _evs = _sat_events.setdefault(_sat, {})
+                _ev = _evs.get(_anom.key)
+                if _ev is None:
+                    _evs[_anom.key] = {
+                        "date": _date,
+                        "description": f"{_anom.key}: {_anom.title or 'Satellite issue'}",
+                        "type": "Satellite",
+                    }
+                elif _date < _ev["date"]:
+                    _ev["date"] = _date
+
     for _sat in stats:
+        # Override satellite issues with the anomaly-based figure (keeping the
+        # planned total constant), and expose the events + impacted datatakes.
+        _u = stats[_sat]["unavailability"]
+        _planned = stats[_sat]["success"] + _u["sat"] + _u["acq"] + _u["other"]
+        _u["sat"] = _sat_hours.get(_sat, 0.0)
+        stats[_sat]["success"] = max(
+            0.0, _planned - (_u["sat"] + _u["acq"] + _u["other"])
+        )
+        stats[_sat]["success_percentage"] = (
+            100.0 * stats[_sat]["success"] / _planned if _planned else 100.0
+        )
+        stats[_sat].setdefault("events", {})["sat_events"] = sorted(
+            _sat_events.get(_sat, {}).values(), key=lambda x: x["date"]
+        )
         stats[_sat]["impacted_datatakes"] = list(
             _impacted_by_sat.get(_sat, {}).values()
         )

--- a/apps/routes/home/routes.py
+++ b/apps/routes/home/routes.py
@@ -1771,6 +1771,99 @@ def admin_space_segment():
         for sat in satellites
     }
 
+    # ---- Impacted-datatakes table: UNION of two sources, deduped by datatake.
+    # (1) ES completeness feed via last_attached_ticket (the original behaviour) —
+    #     covers S1A/S2/S3/S5P, whose datatakes carry the CAMS ticket linkage.
+    # (2) Ingested CAMS anomalies (anomalies.datatakes_completeness) joined against
+    #     the period datatakes cache — recovers S1C/S1D, whose datatakes reach us
+    #     WITHOUT the ES ticket linkage.
+    # Both keep only datatakes with L0 completeness < 100%. Issue type: source (1)
+    # uses the datatake cams_origin; source (2) maps the anomaly category to the
+    # old 3-bucket vocabulary (Platform->Satellite, Acquisition->Acquisition, else
+    # "Other (<category>)"). Client-side rendering is unchanged.
+    import ast
+
+    _impacted_by_sat = {}
+
+    def _add_impacted(sat, did, ts, origin, ticket, compl):
+        if not sat or sat not in stats or not did:
+            return
+        bucket = _impacted_by_sat.setdefault(sat, {})
+        prev = bucket.get(did)
+        # Dedup by datatake: keep the worst (lowest) completeness.
+        if prev is None or compl < prev["completeness"]:
+            bucket[did] = {
+                "datatake_id": did,
+                "observation_time_start": ts,
+                "cams_origin": origin,
+                "last_attached_ticket": ticket,
+                "completeness": compl,
+            }
+
+    # (1) ES-ticketed datatakes (preserves the previous S1A/S2/S3/S5P behaviour).
+    for _d in datatakes_sources:
+        _tkt = _d.get("last_attached_ticket")
+        if not _tkt:
+            continue
+        _compl = acquisitions_utils.recalc_completeness(_d)
+        if _compl >= 100.0:
+            continue
+        _did = _d.get("datatake_id")
+        if not _did:
+            continue
+        _sat = (_d.get("satellite_unit") or _did.split("-")[0]).upper().replace("SNP", "S5P")
+        _add_impacted(
+            _sat, _did, _d.get("observation_time_start"),
+            _d.get("cams_origin") or "", _tkt, _compl,
+        )
+
+    # (2) Anomaly-linked datatakes (recovers S1C/S1D missing the ES linkage).
+    _category_origin = {"Platform": "Satellite", "Acquisition": "Acquisition"}
+    _dt_lookup = {
+        _d.get("datatake_id"): _d
+        for _d in datatakes_sources
+        if _d.get("datatake_id")
+    }
+    for _anom in (anomalies_model.get_anomalies() or []):
+        _raw = _anom.datatakes_completeness
+        if not _raw:
+            continue
+        try:
+            _entries = ast.literal_eval(_raw) if isinstance(_raw, str) else _raw
+        except (ValueError, SyntaxError):
+            continue
+        if not isinstance(_entries, list):
+            continue
+        _origin = _category_origin.get(_anom.category, _anom.category or "Other")
+        for _e in _entries:
+            if not isinstance(_e, dict):
+                continue
+            _did = _e.get("datatakeID")
+            _dt = _dt_lookup.get(_did) if _did else None
+            if not _dt:
+                continue
+            # Skip only true no-data rows (no completeness at ANY level). S2/S5P
+            # track completeness at L1/L2 (no L0), so we must not require L0 here
+            # or every S2/S5P datatake would be dropped.
+            if all(
+                _dt.get(_k) is None
+                for _k in ("L0_", "L1_", "L2_", "final_completeness_percentage")
+            ):
+                continue
+            _compl = acquisitions_utils.recalc_completeness(_dt)
+            if _compl >= 100.0:
+                continue
+            _sat = _did.split("-")[0].upper().replace("SNP", "S5P")
+            _add_impacted(
+                _sat, _did, _dt.get("observation_time_start"),
+                _origin, _anom.key, _compl,
+            )
+
+    for _sat in stats:
+        stats[_sat]["impacted_datatakes"] = list(
+            _impacted_by_sat.get(_sat, {}).values()
+        )
+
     prev_quarter_label = acquisitions_utils.previous_quarter_label()
 
     return render_template(

--- a/apps/static/assets/js/quarterly-reports/space-segment.js
+++ b/apps/static/assets/js/quarterly-reports/space-segment.js
@@ -115,16 +115,15 @@ class SpaceSegment {
 
 
         Object.keys(this.impactedDatatakesBySatellite).forEach(sat => {
-            if (stats[sat] && stats[sat].datatakes) {
-                this.impactedDatatakesBySatellite[sat] = stats[sat].datatakes.filter(dt => {
-                    // Replication of logic: Impacted = Ticket exists AND completeness < 99.9
-                    return dt.last_attached_ticket && dt.completeness < 100.0;
-                }).map(dt => {
-                    // Convert string dates to JS Date objects for the table sorting
-                    dt.observation_time_start = new Date(dt.observation_time_start);
-                    return dt;
-                });
-            }
+            // Impacted datatakes are now built server-side from the anomaly linkage
+            // (stats[sat].impacted_datatakes), already filtered to real, impacted
+            // datatakes below 100% L0 — including S1C/S1D, which lack the ES ticket
+            // linkage. Just convert the date for table sorting.
+            const impacted = (stats[sat] && stats[sat].impacted_datatakes) || [];
+            this.impactedDatatakesBySatellite[sat] = impacted.map(dt => {
+                dt.observation_time_start = new Date(dt.observation_time_start);
+                return dt;
+            });
         });
 
         console.info(`[SSR] Data loading complete.`);
@@ -503,8 +502,10 @@ class SpaceSegment {
 
             if (!tableEl.length) return;
 
-            // Build datatakes rows
+            // Build datatakes rows (dedup by Data Take ID as a safety net so a
+            // datatake never renders more than once, whatever the source).
             const rows = this.impactedDatatakesBySatellite[sat] || [];
+            const seenIds = new Set();
             const data = rows.map(dt => {
                 const key = dt.datatake_id;
                 const issueDate = dt.observation_time_start
@@ -525,6 +526,10 @@ class SpaceSegment {
                     : "-";
                 const completeness = dt.completeness !== undefined ? dt.completeness.toFixed(2) : "-";
                 return [key, issueDate, issueType, issueLink, completeness, null];
+            }).filter(row => {
+                if (seenIds.has(row[0])) return false;
+                seenIds.add(row[0]);
+                return true;
             });
 
             // Initialize DataTable if not already

--- a/apps/utils/acquisitions_utils.py
+++ b/apps/utils/acquisitions_utils.py
@@ -316,11 +316,12 @@ def previous_quarter_label(today=None):
 def compute_acquisition_stats(acquisitions):
     """
     Per-satellite acquisition (downlink pass) failure stats, read from the
-    cds-cadip-acquisition-pass-status cache. A pass is "failed" when any of the
-    antenna / delivery-push / front-end statuses is not OK. We keep only failures
-    whose cams_origin is an acquisition-service cause ('Acquis'), since satellite
-    causes are already accounted for via the unavailability report and RFI/other
-    causes belong to the "Other" bucket.
+    cds-cadip-acquisition-pass-status cache. A pass counts as an acquisition
+    ISSUE only when it actually impacted completeness — aligned with the
+    Acquisition-Service page (acquisition-service.js): real frame errors
+    (fer_data > 1e-6) AND an acquisition origin ('Acquis'), EXCLUDING passes
+    explicitly flagged as having no impact. Satellite causes are accounted for
+    via the unavailability report; RFI/other causes belong to the "Other" bucket.
 
     Returns: {sat_id: {"total": int, "failed_acq": int, "events": {ref: event}}}
     The caller converts failed_acq into "lost sensing hours" proportionally
@@ -350,15 +351,21 @@ def compute_acquisition_stats(acquisitions):
         s = stats.setdefault(sat, {"total": 0, "failed_acq": 0, "events": {}})
         s["total"] += 1
 
-        ok = (
-            src.get("antenna_status") in (True, "OK")
-            and src.get("delivery_push_status") in (True, "OK")
-            and src.get("front_end_status") in (True, "OK")
+        # Count only acquisition issues that actually impacted completeness —
+        # same criterion as the Acquisition-Service page (acquisition-service.js:210):
+        # real frame errors (fer_data > 1e-6) + acquisition origin, excluding
+        # passes explicitly flagged as having no impact.
+        origin = src.get("cams_origin") or ""
+        raw_desc = (src.get("cams_description") or src.get("notes") or "").lower()
+        try:
+            fer = float(src.get("fer_data") or 0)
+        except (ValueError, TypeError):
+            fer = 0.0
+        no_impact = (
+            "no impact on completeness" in raw_desc or "without impact" in raw_desc
         )
-        if ok:
-            continue
 
-        if "Acquis" in (src.get("cams_origin") or ""):
+        if fer > 1e-6 and "Acquis" in origin and not no_impact:
             s["failed_acq"] += 1
             ref = (
                 src.get("last_attached_ticket")

--- a/apps/utils/acquisitions_utils.py
+++ b/apps/utils/acquisitions_utils.py
@@ -36,10 +36,19 @@ SERVICES = [
 # (EDDS DARC, GFTS, External Server, MCS, ...) are intentionally excluded — those
 # belong to the acquisition service, not the satellite.
 SATELLITE_SUBSYSTEMS = {
-    # platform / payload
-    "SAR", "PDHT", "OCP", "AIS", "MMFU", "STR", "STR-1", "STR-2",
-    # instruments
-    "MSI", "OLCI", "SLSTR", "SRAL", "MWR", "TROPOMI",
+    # Subsystems whose unavailability actually affects L0 acquisition/downlink:
+    # the platform/downlink chain (SAR is S1's L0 instrument, PDHT/OCP downlink,
+    # MMFU onboard memory) plus the primary EO instruments whose raw data IS the
+    # L0 product (MSI for S2, TROPOMI for S5P).
+    "SAR", "PDHT", "OCP", "MMFU", "MSI", "TROPOMI",
+    # Deliberately EXCLUDED (grounded in the original space-segment.js, which only
+    # ever tracked the subsystems above for availability and computed satellite
+    # issues from datatakes — never from these):
+    #   - S3 instruments OLCI/SLSTR/SRAL/MWR -> degrade L1/L2 products, not L0
+    #     (e.g. an SLSTR outage from a CAM manoeuvre leaves L0 at 100%);
+    #   - STR (star tracker) -> geolocation/L1, not L0;
+    #   - AIS -> S1 secondary payload, not the L0 SAR product.
+    # A genuine L0 loss on any satellite still comes through PDHT/OCP above.
 }
 
 

--- a/apps/utils/acquisitions_utils.py
+++ b/apps/utils/acquisitions_utils.py
@@ -30,27 +30,6 @@ SERVICES = [
     "WERUM",
 ]
 
-# Satellite subsystems (platform + instruments). An UNPLANNED unavailability on
-# any of these is counted as a "satellite issue" in the space-segment report,
-# matching the CAMS satellite-unavailability report. Ground-segment subsystems
-# (EDDS DARC, GFTS, External Server, MCS, ...) are intentionally excluded — those
-# belong to the acquisition service, not the satellite.
-SATELLITE_SUBSYSTEMS = {
-    # Subsystems whose unavailability actually affects L0 acquisition/downlink:
-    # the platform/downlink chain (SAR is S1's L0 instrument, PDHT/OCP downlink,
-    # MMFU onboard memory) plus the primary EO instruments whose raw data IS the
-    # L0 product (MSI for S2, TROPOMI for S5P).
-    "SAR", "PDHT", "OCP", "MMFU", "MSI", "TROPOMI",
-    # Deliberately EXCLUDED (grounded in the original space-segment.js, which only
-    # ever tracked the subsystems above for availability and computed satellite
-    # issues from datatakes — never from these):
-    #   - S3 instruments OLCI/SLSTR/SRAL/MWR -> degrade L1/L2 products, not L0
-    #     (e.g. an SLSTR outage from a CAM manoeuvre leaves L0 at 100%);
-    #   - STR (star tracker) -> geolocation/L1, not L0;
-    #   - AIS -> S1 secondary payload, not the L0 SAR product.
-    # A genuine L0 loss on any satellite still comes through PDHT/OCP above.
-}
-
 
 def build_acquisition_payload(acquisitions, edrs_acquisitions, period_id=""):
     payload = {
@@ -575,44 +554,10 @@ def build_space_segment_ssr(datatakes, unavailability, period_start, period_end)
             #        f"DEBUG [{sat}]: Ignoring Ticket {ticket} because completeness is {compl_val}%"
             #    )
 
-        # --- Satellite issues: sourced from the UNPLANNED satellite-subsystem
-        # unavailability records (SAR/PDHT/OCP/instruments), grouped by
-        # unavailability_reference. This matches the CAMS satellite-unavailability
-        # report (S1A = 4, S1C = 2, S1D = 2 for Apr-Jun 2026), which the datatake
-        # /L0 signal alone cannot reproduce (recovered downlinks leave L0 at 100%).
-        # A single reference has one row per affected subsystem sharing the same
-        # duration, so we de-duplicate by reference. Hours use the unavailability
-        # duration (microseconds -> hours), matching the CAMS report's durations.
-        sat_unavail_events = {}
-        for u in unavail_by_sat.get(sat, []):
-            if (u.get("type") or "").strip().lower() != "unplanned":
-                continue
-            subsystem = (u.get("subsystem") or u.get("instrument") or "").upper()
-            if subsystem not in SATELLITE_SUBSYSTEMS:
-                continue
-            ref = u.get("unavailability_reference") or u.get("key")
-            if not ref or ref in sat_unavail_events:
-                continue
-            dur_h = (u.get("unavailability_duration") or 0) / 3_600_000_000.0
-            comment = u.get("comment") or u.get("cams_description") or ""
-            desc = f"{subsystem} unavailability {ref}"
-            if comment:
-                desc += f". {comment}"
-            sat_unavail_events[ref] = {
-                "hours": dur_h,
-                "date": (u.get("start_time") or "0000-00-00")[:10],
-                "description": desc,
-                "type": "Satellite",
-            }
-
-        failedSensingSat = sum(e["hours"] for e in sat_unavail_events.values())
-        # Replace any datatake-derived satellite events with the unavailability
-        # ones (drop the internal "hours" helper key before exposing them).
-        categorized_events["sat_events"] = {
-            ref: {k: v for k, v in e.items() if k != "hours"}
-            for ref, e in sat_unavail_events.items()
-        }
-
+        # Satellite issues are computed in the space-segment route from the anomaly
+        # linkage (Platform-category anomalies with L0-impacted datatakes), so
+        # failedSensingSat stays 0 here and is overridden downstream. Keeping it in
+        # the sum below preserves the planned-vs-success arithmetic.
         totSuccessSensing = totSensing - (
             failedSensingAcq + failedSensingSat + failedSensingOther
         )


### PR DESCRIPTION
The table relied on the ES completeness field last_attached_ticket, which the upstream feed leaves null for the newer units (S1C/S1D/S2C), so their tables were empty despite real impacted datatakes. Build it from the UNION of two sources, deduped by datatake:
 - ES ticket linkage (unchanged for S1A/S2A/S2B/S3/S5P), and
 - ingested CAMS anomalies (anomalies.datatakes_completeness) joined against the period datatakes cache, recovering the units missing the ES linkage. Keep datatakes with completeness < 100% at their primary archived level (recalc L0->L1->L2, so S2/S5P use L1/L2 since they have no L0). Issue type from cams_origin (ES source) or the anomaly category mapped to the 3-bucket vocabulary (Platform->Satellite, Acquisition->Acquisition, else Other). Dedup client-side as a safety net.