### PR TITLE
OPSOCS-915 follow-up: datatake-based acquisition issues + acq-plan link fix

### DIFF
--- a/apps/ingestion/acquisition_plans/acq_link_page.py
+++ b/apps/ingestion/acquisition_plans/acq_link_page.py
@@ -53,7 +53,12 @@ class SatelliteAcqPlanLink:
         # Get filename
         # Split and get latest two parts of the name
         # logger.debug("Parsing Url: %s", self.ref_url)
-        basename = os.path.basename(self.ref_url)
+        # Drop any query string / fragment first (e.g. "?download=true"): without
+        # this, a URL like "..._20230615t194000?download=true" leaks the suffix
+        # into the date token and strptime fails with
+        # "unconverted data remains: ?download=true".
+        url_path = urlparse(self.ref_url).path
+        basename = os.path.basename(url_path)
         basename_noext = os.path.splitext(basename)[0]
         name_components = basename_noext.split("_")
         logger.debug("Name components: %s", name_components)
@@ -227,16 +232,28 @@ class AcqPlanLinksPageParser:
                 html_link_list = sat_acqplan_links_element.find_all("a", href=True)
                 ref_links = [link_el["href"] for link_el in html_link_list]
                 logger.debug("Retrieved links from page: %s", ref_links)
-                # Retrieve the list of urls sorted by end date
-                list_of_acq_link_urls = list(
-                    sorted(
-                        [
+                # Build link objects one-by-one and tolerate individual failures.
+                # The href values come from an external page (ESA) whose filename
+                # convention can drift; parsing one unexpected link must NOT abort
+                # the whole acquisition-plans ingestion (and, via the scheduler's
+                # run_all, every job registered after it). Skip and log the odd
+                # ones, keep the parseable ones.
+                list_of_acq_link_urls = []
+                for ref_link in ref_links:
+                    try:
+                        list_of_acq_link_urls.append(
                             SatelliteAcqPlanLink(ref_link, self.base_url)
-                            for ref_link in ref_links
-                        ],
-                        key=lambda x: x.end_date,
-                    )
-                )
+                        )
+                    except Exception as ex:
+                        logger.warning(
+                            "Skipping unparseable acq-plan link for satellite %s: "
+                            "%r (%s)",
+                            sat,
+                            ref_link,
+                            ex,
+                        )
+                # Sort by end date (all retained links parsed successfully)
+                list_of_acq_link_urls.sort(key=lambda x: x.end_date)
                 self._acq_link_objs.add_acq_link_url_list(sat, list_of_acq_link_urls)
 
     @property

--- a/apps/routes/home/routes.py
+++ b/apps/routes/home/routes.py
@@ -1725,25 +1725,23 @@ def admin_space_segment():
         for dt in sat.get("datatakes", []):
             dt["completeness"] = acquisitions_utils.recalc_completeness(dt)
 
-    acq_key = acquisitions_cache.acquisitions_cache_key.format(cache_prefix, cache_range)
-    acq_sources = acquisitions_utils._cache_to_list(flask_cache.get(acq_key))
-    acq_stats = acquisitions_utils.compute_acquisition_stats(acq_sources)
-    for sat_id, sat_data in satellites.items():
-        a = acq_stats.get(sat_id)
-        if not a or a["total"] <= 0 or a["failed_acq"] <= 0:
-            continue
-        unavail = sat_data["unavailability"]
-        planned = (
-            sat_data["success"] + unavail["sat"] + unavail["acq"] + unavail["other"]
-        )
-        acq_hours = (a["failed_acq"] / a["total"]) * planned
-        unavail["acq"] += acq_hours
-        sat_data["success"] = max(
-            0.0, planned - (unavail["sat"] + unavail["acq"] + unavail["other"])
-        )
-        sat_data["events"]["acq_events"] = sorted(
-            a["events"].values(), key=lambda x: x["date"]
-        )
+    # Acquisition and "Other" event lists and lost-sensing hours are computed
+    # from the datatakes feed in build_space_segment_ssr (categorized by
+    # cams_origin: "Acquis" -> Acquisition, else -> Other), matching the original
+    # pre-SSR space-segment.js logic (showSensingStatistics).
+    #
+    # The CADIP pass-status feed override (compute_acquisition_stats) was removed:
+    # it flagged a downlink as an "Acquisition issue" from its frame-error rate
+    # alone (fer_data > 1e-6), independently of whether any L0 completeness
+    # actually dropped. That surfaced non-impactful passes such as the
+    # SGS/GSANOM-22873 duplicate (OPSOCS-915) and diverged from both the original
+    # page and the quarterly report. Sourcing acquisition issues from the
+    # datatakes (which carry the real completeness) restores the original
+    # behaviour and inherently drops the phantom events.
+    #
+    # Satellite events remain re-sourced from the anomaly linkage below (Platform
+    # category), matching the events page.
+    _all_anomalies = anomalies_model.get_anomalies() or []
 
     for sat_id, sat_data in satellites.items():
 
@@ -1847,7 +1845,7 @@ def admin_space_segment():
             except (ValueError, TypeError):
                 return 0.0
         return 0.0
-    for _anom in (anomalies_model.get_anomalies() or []):
+    for _anom in _all_anomalies:
         _raw = _anom.datatakes_completeness
         if not _raw:
             continue

--- a/apps/utils/acquisitions_utils.py
+++ b/apps/utils/acquisitions_utils.py
@@ -315,6 +315,11 @@ def compute_acquisition_stats(acquisitions):
     The caller converts failed_acq into "lost sensing hours" proportionally
     (failed_acq / total * planned_sensing_hours), keeping the page's hour-based
     accounting consistent.
+
+    NOTE: as of the space-segment popup alignment to the original pre-SSR logic,
+    acquisition issues are sourced from the datatakes feed (by cams_origin) in
+    build_space_segment_ssr, and this pass-status helper is no longer wired into
+    the space-segment route. It is retained for potential reuse.
     """
     stats = {}
     for row in acquisitions or []:


### PR DESCRIPTION
Removes the CADIP pass-status override (acquisition issues now come from the datatakes feed; fixes the phantom SGS/GSANOM-22873 event, 3-bucket taxonomy per page docs). Also fixes acq-plan KML link parsing on query-string URLs and makes it resilient to format drift.