### PR TITLE
Feature/opsocs 967 Sentiboard no events calendar updated

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -95,7 +95,10 @@ def start_scheduler(app):
 
         def anomalies_cache_loader():
             with app.app_context():
-                events.load_anomalies_cache_previous_quarter()
+                # force=True: this key is warm almost all the time, so without it
+                # the reload is skipped and the events calendar keeps serving the
+                # snapshot taken the first time the key was populated.
+                events.load_anomalies_cache_previous_quarter(force=True)
 
         def datatakes_cache_loader():
             with app.app_context():

--- a/apps/cache/modules/events.py
+++ b/apps/cache/modules/events.py
@@ -84,17 +84,21 @@ def load_anomalies_cache_last_quarter():
     )
 
 
-def load_anomalies_cache_previous_quarter():
+def load_anomalies_cache_previous_quarter(force=False):
     """
     Fetch the anomalies since the beginning of the previous, completed quarter up to today from the local MYSQL DB,
     and store results in cache for future reuse. The start time is set at 00:00 of the first day of the temporal
     interval; the stop time is set at 23:59:59 of today
+
+    Pass force=True to rebuild the cache even when the key is still warm. The
+    scheduler does so hourly: without it, the first run warms the key and every
+    later run returns here, leaving the cache frozen until its TTL expires.
     """
 
     cache_key = anomalies_cache_key.format("previous", "quarter")
-    if flask_cache.get(cache_key):
-        return 
-    
+    if not force and flask_cache.get(cache_key):
+        return
+
     logger.info("[BEG] Loading Anomalies Cache since the previous quarter...")
     cache_start_time = perf_counter()
 
@@ -136,9 +140,16 @@ def load_anomalies_cache_previous_quarter():
     )
 
 
-def load_anomalies_cache_full_history():
+def load_anomalies_cache_full_history(force=False):
+    """
+    Fetch the whole anomaly history from the local DB and cache it.
+
+    This cache now only serves calendar months older than the recent window (see
+    load_anomalies_for_month); anomalies that far back no longer change, so the
+    long TTL is intentional. Pass force=True to rebuild it on demand.
+    """
     cache_key = anomalies_cache_key.format("full", "history")
-    if flask_cache.get(cache_key):
+    if not force and flask_cache.get(cache_key):
         logger.debug("[SKIP] full history cache already warm")
         return
 
@@ -170,6 +181,11 @@ def _set_anomalies_cache(period_id, period_data):
         seconds_validity = 3600          # 1 hour
     elif period_id in ("7d", "30d"):
         seconds_validity = 43200         # 12 hours
+    elif period_id == "previous-quarter":
+        # Serves the recent months of the events calendar, so it must not go
+        # stale: the scheduler rebuilds it hourly, and this TTL bounds how old
+        # the data can get should the scheduler thread stop running.
+        seconds_validity = 3600          # 1 hour
     else:
         seconds_validity = events_cache_duration  # 7 days for quarter/history
     if period_id == "previous-quarter":
@@ -188,6 +204,41 @@ def _set_anomalies_cache(period_id, period_data):
         ),
         seconds_validity,
     )
+
+
+def load_anomalies_for_month(year, month):
+    """
+    Return (raw_anomalies, cache_key) for the anomalies that should populate the
+    events calendar for the given month.
+
+    Recent months - those from the start of the previous completed quarter
+    onwards - are served by the "previous-quarter" cache, which the scheduler
+    rebuilds hourly, so newly ingested anomalies reach the calendar within the
+    hour. Older months are served by the long-lived "full-history" cache, which
+    avoids replaying a 2022-to-today query on every calendar navigation.
+    """
+
+    recent_start, _ = date_utils.prev_quarter_interval_from_date(datetime.today())
+
+    if (year, month) >= (recent_start.year, recent_start.month):
+        period = ("previous", "quarter")
+        loader = load_anomalies_cache_previous_quarter
+    else:
+        period = ("full", "history")
+        loader = load_anomalies_cache_full_history
+
+    cache_key = anomalies_cache_key.format(*period)
+    logger.debug("Serving anomalies for %04d-%02d from %s", year, month, cache_key)
+
+    # Populates the key when cold or expired; a no-op while it is still warm
+    loader()
+
+    cache_entry = flask_cache.get(cache_key)
+    if not cache_entry:
+        logger.warning("Anomalies cache %s still empty after load", cache_key)
+        return [], cache_key
+
+    return json.loads(cache_entry.data), cache_key
 
 
 def load_news_cache_last_quarter():

--- a/apps/routes/home/routes.py
+++ b/apps/routes/home/routes.py
@@ -753,15 +753,12 @@ def events_data():
         return jsonify({"error": "Missing year or month"}), 400
 
     try:
-        events_cache.load_anomalies_cache_full_history()
-        cache_key = events_cache.anomalies_cache_key.format("full", "history")
-
-        cache_entry = events_cache.flask_cache.get(cache_key)
-
-        raw_anomalies = json.loads(cache_entry.data) if cache_entry else []
+        # Recent months come from the hourly-refreshed previous-quarter cache;
+        # older months from the long-lived full-history cache.
+        raw_anomalies, cache_key = events_cache.load_anomalies_for_month(year, month)
 
         if not raw_anomalies:
-            current_app.logger.info(f"[EVENTS DATA] no cache anomalies")
+            current_app.logger.info(f"[EVENTS DATA] no cache anomalies in {cache_key}")
             return jsonify({"anomalies": [], "anomalies_by_date": {}, "events": []})
 
         def serialize_anomalie(a):

--- a/apps/routes/rest/routes.py
+++ b/apps/routes/rest/routes.py
@@ -516,7 +516,9 @@ def add_anomaly():
             data["newsTitle"],
         )
 
-        events_cache.load_anomalies_cache_previous_quarter()  # Explicitly force cache reloading
+        events_cache.load_anomalies_cache_previous_quarter(
+            force=True
+        )  # Explicitly force cache reloading
     except Exception as ex:
         return Response(
             json.dumps({"error": "500"}), mimetype="application/json", status=500
@@ -549,7 +551,9 @@ def update_anomaly():
             data["newsTitle"],
         )
 
-        events_cache.load_anomalies_cache_previous_quarter()  # Explicitly force cache reloading
+        events_cache.load_anomalies_cache_previous_quarter(
+            force=True
+        )  # Explicitly force cache reloading
     except Exception as ex:
         return Response(
             json.dumps({"error": "500"}), mimetype="application/json", status=500

--- a/apps/static/assets/js/events/calendar.js
+++ b/apps/static/assets/js/events/calendar.js
@@ -543,52 +543,6 @@ class CalendarWidget {
             : '<p>No valid datatakes</p>';
     }
 
-    calcDatatakeStatus(anomaly, datatake_id) {
-        const dtCompletenessArray = anomaly.datatakes_completeness || [];
-        if (!dtCompletenessArray.length) return null;
-
-        for (let dtObj of dtCompletenessArray) {
-            try {
-                // Normalize both string and object cases
-                const parsed = typeof dtObj === "string"
-                    ? JSON.parse(dtObj.replaceAll("'", '"'))
-                    : dtObj;
-
-                // Case 1: Old format -> {"S1C-35496": {"L0_":86.3,"L1_":0,"L2_":0}}
-                for (const [key, val] of Object.entries(parsed)) {
-                    if (key.trim().toUpperCase() === datatake_id.trim().toUpperCase()) {
-                        const numericValues = Object.values(val).filter(v => typeof v === "number");
-                        const completeness = this.calcDatatakeCompleteness(numericValues);
-
-                        if (completeness >= 90) return 'ok';
-                        if (completeness >= 10 && completeness < 90) return 'partial';
-                        if (completeness < 10) return 'failed';
-                    }
-                }
-
-                // Case 2: New format -> {datatakeID:"S1C-35496", L0_:86.3, L1_:0, L2_:0}
-                if (
-                    parsed.datatakeID &&
-                    parsed.datatakeID.trim().toUpperCase() === datatake_id.trim().toUpperCase()
-                ) {
-                    const numericValues = [parsed.L0_, parsed.L1_, parsed.L2_]
-                        .filter(v => typeof v === "number");
-                    const completeness = this.calcDatatakeCompleteness(numericValues);
-
-                    if (completeness >= 90) return 'ok';
-                    if (completeness >= 10 && completeness < 90) return 'partial';
-                    if (completeness < 10) return 'failed';
-                }
-
-            } catch (ex) {
-                console.warn("Error parsing dt completeness", ex, dtObj);
-                continue;
-            }
-        }
-
-        return null;
-    }
-
     overrideS1DatatakesId(datatake_id) {
         let num = datatake_id.trim().substring(4);
         let hexaNum = parseInt(num).toString(16);

--- a/apps/utils/events_utils.py
+++ b/apps/utils/events_utils.py
@@ -260,7 +260,8 @@ def build_event_instance(a, logger=None):
 
     category = a.get("category", "Unknown")
 
-    datatakes_raw = parse_datatakes_completeness(a.get("datatakes_completeness"))
+    raw_completeness = a.get("datatakes_completeness")
+    datatakes_raw = parse_datatakes_completeness(raw_completeness)
     # current_app.logger.info(f"[PARSE DATATAKES COMPLETENESS]: {datatakes_raw}")
 
     datatake_ids = []
@@ -268,6 +269,17 @@ def build_event_instance(a, logger=None):
     all_recovered = True
     any_partial = False
     any_failed = False
+    # Tracks datatakes whose completeness could not be determined. Pre-SSR these
+    # produced an explicit "undef" dot (grey); they must not be silently dropped
+    # nor be reported as "failed".
+    any_unknown = False
+
+    # parse_datatakes_completeness() returns [] both when the field is absent and
+    # when it is present but malformed. A non-empty raw field that parses to
+    # nothing is undetermined, not absent.
+    if raw_completeness and not datatakes_raw:
+        all_recovered = False
+        any_unknown = True
 
     for dt_entry in datatakes_raw:
         try:
@@ -298,8 +310,21 @@ def build_event_instance(a, logger=None):
                 values = [dt_entry.get("L0_"), dt_entry.get("L1_"), dt_entry.get("L2_")]
                 values = [v for v in values if isinstance(v, (int, float))]
 
-                # no numeric values -> skip
+                # No numeric values -> status is undetermined, not "failed" and
+                # not "recovered". Emit an explicit "undef" record so the
+                # datatake still appears in the impacted list with a grey dot,
+                # instead of vanishing from the panel.
                 if not values:
+                    all_recovered = False
+                    any_unknown = True
+                    datatake_records.append(
+                        {
+                            "datatake_id": dtid,
+                            "values": [],
+                            "completeness": None,
+                            "status": "undef",
+                        }
+                    )
                     continue
 
                 completeness = calc_completeness(values)
@@ -390,49 +415,65 @@ def build_event_instance(a, logger=None):
                     )
 
             else:
-                # unknown entry type: skip but mark not all recovered to be safe
+                # unknown entry type: status undetermined, never "failed"
                 current_app.logger.debug(
                     f"[build_event_instance] Unknown datatake entry: {dt_entry}"
                 )
                 all_recovered = False
+                any_unknown = True
 
         except Exception as exc:
             current_app.logger.warning(
                 f"[build_event_instance] Parse error for entry {dt_entry}: {exc}"
             )
             all_recovered = False
+            any_unknown = True
             continue
 
-    # If there were datatake IDs but none produced valid completeness records -> skip event
-    if datatake_ids and not datatake_records:
+    # If there were datatake IDs but none produced valid completeness records -> skip event.
+    # Only suppress the event when the records were omitted because every datatake was
+    # complete; if we merely failed to parse them, keep the event visible with an
+    # undetermined status, as the pre-SSR calendar did.
+    if datatake_ids and not datatake_records and not any_unknown:
         #  if logger:
         #      logger.info(
         #          f"[SKIP EVENT] {a.get('key')} - has datatake id's but not completeness data (or all were 100%)."
         #      )
         return None
 
-    # If no datatake info at all -> skip
-    if not datatake_ids and not datatake_records:
+    # If no datatake info at all -> skip. A parse failure is not the same as
+    # "no information": it leaves the event visible with an undetermined status
+    # rather than dropping it off the calendar without trace.
+    if not datatake_ids and not datatake_records and not any_unknown:
         # if logger:
         #     logger.info(
         #         f"[SKIP EVENT] {a.get('key')} - no datatake id's information available"
         #     )
         return None
 
-    # overall_status: failed > partial > ok (JS-like semantics)
-    overall_status = "unknown"
+    # overall_status precedence: failed > partial > unknown > ok (JS-like semantics).
+    # "unknown" must keep its own slot: real severity outranks it, but it outranks
+    # "ok" so an unparseable entry can never let the event claim full recovery.
     if any_failed:
         overall_status = "failed"
     elif any_partial:
         overall_status = "partial"
-    elif all_recovered:
+    elif any_unknown or not all_recovered:
+        overall_status = "unknown"
+    else:
         overall_status = "ok"
 
     full_recover = overall_status == "ok"
     partial_recover = overall_status == "partial"
 
-    # color mapping (you can tune hexes)
-    color = "#31ce36" if full_recover else ("#F9A825" if partial_recover else "#D32F2F")
+    # Colours follow the Completeness Status legend (events.css): green acquired,
+    # amber partial, red unavailable, grey undetermined.
+    color = {
+        "ok": "#31ce36",
+        "partial": "#F9A825",
+        "failed": "#D32F2F",
+        "unknown": "#9e9e9e",
+    }[overall_status]
 
     instance = {
         "id": a.get("key"),


### PR DESCRIPTION
Fixes an issue where hourly scheduled updates for event anomalies were silently skipped due to a cache guardrail introduced.


Separated Caller Logic:

    Page Requests: Retain the guardrail to prevent heavy rebuilds during navigation and keep load times fast.

    Scheduled Job: Bypasses/overrides the guardrail to force an hourly rebuild of recent anomaly data.

Tiered Cache Handling:

    Recent Data: Served by the hourly-refreshed cache.

    Historical Data: Continues to pull from the static full-history cache (2022 to present).
    
This PR separates the caller paths so user page requests remain fast while the hourly background scheduler can force cache rebuilds.